### PR TITLE
Make ember-cli-htmlbars support HTMLBars only.

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -10,8 +10,6 @@ module.exports = {
 
     this._super.included.apply(this, arguments);
 
-    this.registerTransforms(app.registry);
-
     // ensure that broccoli-ember-hbs-template-compiler is not processing hbs files
     app.registry.remove('template', 'broccoli-ember-hbs-template-compiler');
 
@@ -41,36 +39,19 @@ module.exports = {
   },
 
   htmlbarsOptions: function() {
-    var emberVersion = require(this.project.root + '/bower.json').ember;
-    var projectConfig = this.app.project.config(this.app.env);
-    var htmlbarsEnabled = !/^1\.[0-9]\./.test(emberVersion);
+    var projectConfig = this.project.config(process.env.EMBER_ENV);
 
-    var htmlbarsOptions;
-    if (htmlbarsEnabled) {
-      htmlbarsOptions = {
-        isHTMLBars: true,
-        FEATURES: projectConfig.EmberENV.FEATURES,
-        templateCompiler: require(path.join(this.emberPath(), 'ember-template-compiler')),
+    var htmlbarsOptions = {
+      isHTMLBars: true,
+      FEATURES: projectConfig.EmberENV.FEATURES,
+      templateCompiler: require(path.join(this.emberPath(), 'ember-template-compiler')),
 
-        plugins: {
-          ast: this.astPlugins()
-        }
-      };
-    }
+      plugins: {
+        ast: this.astPlugins()
+      }
+    };
 
     return htmlbarsOptions;
-  },
-
-  registerTransforms: function(registry) {
-    //var TransformEachInToHash = require('./ext/plugins/transform-each-in-to-hash');
-
-    //// we have to wrap these in an object so the ember-cli
-    //// registry doesn't try to call `new` on them (new is actually
-    //// called within htmlbars when compiling a given template).
-    //registry.add('htmlbars-ast-plugin', {
-    //  name: 'transform-each-in-to-hash',
-    //  plugin: TransformEachInToHash
-    //});
   },
 
   astPlugins: function() {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var Filter = require('broccoli-filter');
-var handlbarsTemplateCompiler = require('ember-template-compiler');
 
 function TemplateCompiler (inputTree, options) {
   if (!(this instanceof TemplateCompiler)) {
@@ -9,16 +8,10 @@ function TemplateCompiler (inputTree, options) {
   Filter.call(this, inputTree, options); // this._super()
 
   this.options = options || {};
-
   this.inputTree = inputTree;
 
-  if (this.options.isHTMLBars) {
-    this.precompile = this.options.templateCompiler.precompile;
-    this.templateWrapper = "export default Ember.HTMLBars.template(";
-  } else {
-    this.precompile = handlbarsTemplateCompiler.precompile;
-    this.templateWrapper = "export default Ember.Handlebars.template(";
-  }
+  this.precompile = this.options.templateCompiler.precompile;
+  this.registerPlugin = this.options.templateCompiler.registerPlugin;
 
   this.registerPlugins();
   this.initializeFeatures();
@@ -33,11 +26,10 @@ TemplateCompiler.prototype.registerPlugins = function registerPlugins() {
   var plugins = this.options.plugins;
   var templateCompiler = this.options.templateCompiler;
 
-  if (plugins && templateCompiler) {
+  if (plugins) {
     for (var type in plugins) {
       for (var i = 0, l = plugins[type].length; i < l; i++) {
-
-        templateCompiler.registerPlugin(type, plugins[type][i]);
+        this.registerPlugin(type, plugins[type][i]);
       }
     }
   }
@@ -55,7 +47,7 @@ TemplateCompiler.prototype.initializeFeatures = function initializeFeatures() {
 };
 
 TemplateCompiler.prototype.processString = function (string, relativePath) {
-  return this.templateWrapper + this.precompile(string, false) + ');';
+  return "export default Ember.HTMLBars.template(" + this.precompile(string, false) + ');';
 }
 
 module.exports = TemplateCompiler;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "mocha": "^1.21.4"
   },
   "dependencies": {
-    "broccoli-filter": "^0.1.6",
-    "ember-template-compiler": "^1.9.0-alpha"
+    "broccoli-filter": "^0.1.6"
   }
 }

--- a/test/template_compiler_test.js
+++ b/test/template_compiler_test.js
@@ -4,8 +4,6 @@ var fs = require('fs');
 var broccoli = require('broccoli');
 var assert = require('assert');
 var templateCompilerFilter = require('../index');
-var handlbarsTemplateCompiler = require('ember-template-compiler');
-
 var builder;
 
 describe('templateCompilerFilter', function(){
@@ -17,87 +15,48 @@ describe('templateCompilerFilter', function(){
     }
   });
 
-  describe('HTMLBars', function() {
-    var htmlbarsOptions, htmlbarsPrecompile;
+  var htmlbarsOptions, htmlbarsPrecompile;
 
-    beforeEach(function() {
-      htmlbarsOptions = {
-        isHTMLBars: true,
-        templateCompiler: require('../bower_components/ember/ember-template-compiler')
-      };
+  beforeEach(function() {
+    htmlbarsOptions = {
+      isHTMLBars: true,
+      templateCompiler: require('../bower_components/ember/ember-template-compiler')
+    };
 
-      htmlbarsPrecompile = htmlbarsOptions.templateCompiler.precompile;
-    });
+    htmlbarsPrecompile = htmlbarsOptions.templateCompiler.precompile;
+  });
 
-    afterEach(function() {
+  afterEach(function() {
 
-    });
+  });
 
-    it('precompiles templates into htmlbars', function(){
-      var tree = templateCompilerFilter(sourcePath, htmlbarsOptions);
+  it('precompiles templates into htmlbars', function(){
+    var tree = templateCompilerFilter(sourcePath, htmlbarsOptions);
 
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function(results) {
-        var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
-        var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
-        var expected = "export default Ember.HTMLBars.template(" + htmlbarsPrecompile(source) + ");";
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(results) {
+      var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
+      var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
+      var expected = "export default Ember.HTMLBars.template(" + htmlbarsPrecompile(source) + ");";
 
-        assert.equal(actual,expected,'They dont match!')
-      });
-    });
-
-    it('passes FEATURES to compiler', function(){
-      htmlbarsOptions.FEATURES = {
-        'ember-htmlbars-component-generation': true
-      };
-
-      var tree = templateCompilerFilter(sourcePath, htmlbarsOptions);
-
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function(results) {
-        var actual = fs.readFileSync(results.directory + '/web-component-template.js', { encoding: 'utf8'});
-        var source = fs.readFileSync(sourcePath + '/web-component-template.hbs', { encoding: 'utf8' });
-        var expected = "export default Ember.HTMLBars.template(" + htmlbarsPrecompile(source) + ");";
-
-        assert.equal(actual,expected,'They dont match!')
-      });
+      assert.equal(actual,expected,'They dont match!')
     });
   });
 
-  describe('handlebars', function() {
-    it('compiles .handlebars file', function() {
-      var tree = templateCompilerFilter(sourcePath);
+  it('passes FEATURES to compiler', function(){
+    htmlbarsOptions.FEATURES = {
+      'ember-htmlbars-component-generation': true
+    };
 
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function(results) {
-        var actual = fs.readFileSync(results.directory + '/non-standard-extension.js', { encoding: 'utf8'});
-        var source = fs.readFileSync(sourcePath + '/non-standard-extension.handlebars', { encoding: 'utf8' });
-        var expected = 'export default Ember.Handlebars.template(' + handlbarsTemplateCompiler.precompile(source, false) + ');';
+    var tree = templateCompilerFilter(sourcePath, htmlbarsOptions);
 
-        assert.equal(actual,expected,'They dont match!')
-      });
-    });
-
-    function assertOutput(results) {
-      var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
-      var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
-      var expected = 'export default Ember.Handlebars.template(' + handlbarsTemplateCompiler.precompile(source, false) + ');';
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(results) {
+      var actual = fs.readFileSync(results.directory + '/web-component-template.js', { encoding: 'utf8'});
+      var source = fs.readFileSync(sourcePath + '/web-component-template.hbs', { encoding: 'utf8' });
+      var expected = "export default Ember.HTMLBars.template(" + htmlbarsPrecompile(source) + ");";
 
       assert.equal(actual,expected,'They dont match!')
-    }
-
-    it('precompiles templates into handlebars by default', function(){
-      var tree = templateCompilerFilter(sourcePath);
-
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(assertOutput);
-    });
-
-    it('precompiles templates into handlebars when HTMLBars option is false', function(){
-      var tree = templateCompilerFilter(sourcePath, { htmlbarsOptions: false });
-
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(assertOutput);
     });
   });
 });


### PR DESCRIPTION
Prior versions supported Handlebars 2.0 and HTMLBars, but now that HTMLBars is enabled by default in the latest stable version we are removing the Handlebars compiling support.

If you need Handlebars support please continue to use the latest 0.6.x version.