### PR TITLE
bowerDirectory can be an absolute path

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -57,7 +57,7 @@ module.exports = {
       templateCompilerPath = this.project.bowerDirectory + '/ember/ember-template-compiler';
     }
 
-    return path.join(this.project.root, templateCompilerPath);
+    return path.resolve(this.project.root, templateCompilerPath);
   },
 
   htmlbarsOptions: function() {


### PR DESCRIPTION
This change fixes a defect which occurs when `bowerDirectory` is set to an absolute path.

Using `path.resolve` over `path.join` enables the paths to be either relative or absolute.