### PR TITLE
Expose precompile on registered plugin wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,25 @@ module.exports = {
   }
 };
 ```
+
+### Precompile HTMLBars template strings within other addons
+
+```javascript
+module.exports = {
+  name: 'my-addon-name',
+
+  setupPreprocessorRegistry: function(type, registry) {
+    var htmlbarsPlugin = registry.load('template').find(function(plugin) {
+      return plugin.name === 'ember-cli-htmlbars';
+    });
+
+    // precompile any htmlbars template string via the precompile method on the
+    // ember-cli-htmlbars plugin wrapper; `precompiled` will be a string of the
+    // form:
+    //
+    //   Ember.HTMLBars.template(function() {...})
+    //
+    var precompiled = htmlbarsPlugin.precompile("{{my-component}}");
+  }
+};
+```

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var checker = require('ember-cli-version-checker');
 var htmlbarsCompile = require('./index');
+var utils = require('./utils');
 
 module.exports = {
   name: 'ember-cli-htmlbars',
@@ -27,8 +28,8 @@ module.exports = {
       name: 'ember-cli-htmlbars',
       ext: 'hbs',
       toTree: function(tree) {
-
-        return htmlbarsCompile(tree, self.htmlbarsOptions());
+        var htmlbarsOptions = self.htmlbarsOptions();
+        return htmlbarsCompile(tree, htmlbarsOptions);
       }
     });
 

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -30,6 +30,12 @@ module.exports = {
       toTree: function(tree) {
         var htmlbarsOptions = self.htmlbarsOptions();
         return htmlbarsCompile(tree, htmlbarsOptions);
+      },
+
+      precompile: function(string) {
+        var htmlbarsOptions = self.htmlbarsOptions();
+        var templateCompiler = htmlbarsOptions.templateCompiler;
+        return utils.template(templateCompiler, string);
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var utils = require('./utils');
 var Filter = require('broccoli-filter');
 
 function TemplateCompiler (inputTree, options) {
@@ -40,17 +41,13 @@ TemplateCompiler.prototype.initializeFeatures = function initializeFeatures() {
   var FEATURES = this.options.FEATURES;
   var templateCompiler = this.options.templateCompiler;
 
-  if (FEATURES && templateCompiler) {
-    for (var feature in FEATURES) {
-      templateCompiler._Ember.FEATURES[feature] = FEATURES[feature];
-    }
-  }
+  utils.initializeFeatures(templateCompiler, FEATURES);
 };
 
 TemplateCompiler.prototype.processString = function (string, relativePath) {
-  return 'export default Ember.HTMLBars.template(' + this.precompile(string, {
+  return 'export default ' + utils.template(this.options.templateCompiler, string, {
     moduleName: relativePath
-  }) + ');';
+  }) + ';';
 };
 
 module.exports = TemplateCompiler;

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  initializeFeatures: function(templateCompiler, FEATURES) {
+    if (FEATURES && templateCompiler) {
+      for (var feature in FEATURES) {
+        templateCompiler._Ember.FEATURES[feature] = FEATURES[feature];
+      }
+    }
+  },
+
+  template: function(templateCompiler, string, options) {
+    var precompiled = templateCompiler.precompile(string, options);
+    return 'Ember.HTMLBars.template(' + precompiled + ')';
+  }
+};


### PR DESCRIPTION
This adds a `precompile` function to the plugin wrapper, so it is possible to precompile template strings within other addons:

```js
// my-addon/index.js
module.exports = {
  name: 'my-addon-using-babel-transformer',

  setupPreprocessorRegistry: function(type, registry) {
    var htmlbarsPlugin = registry.load('template').find(function(plugin) {
      return plugin.name === 'ember-cli-htmlbars';
    });

    // will be a string like 'Ember.HTMLBars.template(function() {...})'
    var precompiled = htmlbarsPlugin.precompile("{{my-component}}");
  }
}
```

---

This addresses pangratz/ember-cli-htmlbars-inline-precompile#7