### PR TITLE
Fix assertions for Ember 1.13+.

### DIFF
--- a/test/template_compiler_test.js
+++ b/test/template_compiler_test.js
@@ -37,7 +37,7 @@ describe('templateCompilerFilter', function(){
     return builder.build().then(function(results) {
       var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
       var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
-      var expected = 'export default Ember.HTMLBars.template(' + htmlbarsPrecompile(source) + ');';
+      var expected = 'export default Ember.HTMLBars.template(' + htmlbarsPrecompile(source, { moduleName: 'template.hbs' }) + ');';
 
       assert.equal(actual,expected,'They dont match!');
     });
@@ -54,7 +54,7 @@ describe('templateCompilerFilter', function(){
     return builder.build().then(function(results) {
       var actual = fs.readFileSync(results.directory + '/web-component-template.js', { encoding: 'utf8'});
       var source = fs.readFileSync(sourcePath + '/web-component-template.hbs', { encoding: 'utf8' });
-      var expected = 'export default Ember.HTMLBars.template(' + htmlbarsPrecompile(source) + ');';
+      var expected = 'export default Ember.HTMLBars.template(' + htmlbarsPrecompile(source, { moduleName: 'web-component-template.hbs' }) + ');';
 
       assert.equal(actual,expected,'They dont match!');
     });


### PR DESCRIPTION
The moduleName is now embedded into the templates in Ember 1.13+ (to provide much better debugging).  We need to pass this option through to the compiler so that it can embed it into the template.