### PR TITLE
load template-compiler from ember-source

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -67,7 +67,13 @@ module.exports = {
       templateCompilerPath = this.project.bowerDirectory + '/ember/ember-template-compiler';
     }
 
-    return path.resolve(this.project.root, templateCompilerPath);
+    var absolutePath = path.resolve(this.project.root, templateCompilerPath);
+
+    if (path.extname(absolutePath) === '') {
+      absolutePath += '.js';
+    }
+
+    return absolutePath;
   },
 
   htmlbarsOptions: function() {

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -60,7 +60,7 @@ module.exports = {
     var config = this.projectConfig();
     var templateCompilerPath = config['ember-cli-htmlbars'] && config['ember-cli-htmlbars'].templateCompilerPath;
 
-    var ember = this.project.findAddonByName('ember-source');
+    var ember = this.project.findAddonByName('ember-core');
     if (ember) {
       return ember.absolutePaths.templateCompiler;
     } else if (!templateCompilerPath) {

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -9,7 +9,7 @@ module.exports = {
   name: 'ember-cli-htmlbars',
 
   init: function() {
-    this._super.init && this._super.init.apply(this, arguments);
+    if (this._super.init) { this._super.init.apply(this, arguments); }
     checker.assertAbove(this, '0.1.2');
   },
 

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -60,7 +60,10 @@ module.exports = {
     var config = this.projectConfig();
     var templateCompilerPath = config['ember-cli-htmlbars'] && config['ember-cli-htmlbars'].templateCompilerPath;
 
-    if (!templateCompilerPath) {
+    var ember = this.project.findAddonByName('ember-source');
+    if (ember) {
+      return ember.absolutePaths.templateCompiler;
+    } else if (!templateCompilerPath) {
       templateCompilerPath = this.project.bowerDirectory + '/ember/ember-template-compiler';
     }
 
@@ -70,7 +73,7 @@ module.exports = {
   htmlbarsOptions: function() {
     var projectConfig = this.projectConfig() || {};
     var EmberENV = projectConfig.EmberENV || {};
-    var templateCompilerPath = this.templateCompilerPath() + '.js';
+    var templateCompilerPath = this.templateCompilerPath();
 
     global.EmberENV = EmberENV; // Needed for eval time feature flag checks
     var htmlbarsOptions = {


### PR DESCRIPTION
- [x] fallback to old
- [x] don’t append ‘.js’ as require already does this