### PR TITLE
Fix require caching

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -80,6 +80,15 @@ module.exports = {
     var EmberENV = projectConfig.EmberENV || {};
     var templateCompilerPath = this.templateCompilerPath();
 
+    // ensure we get a fresh templateCompilerModuleInstance per ember-addon
+    // instance NOTE: this is a quick hack, and will only work as long as
+    // templateCompilerPath is a single file bundle
+    //
+    // (╯°□°）╯︵ ɹǝqɯǝ
+    //
+    // we will also fix this in ember for future releases
+    delete require.cache[templateCompilerPath];
+
     global.EmberENV = EmberENV; // Needed for eval time feature flag checks
     var htmlbarsOptions = {
       isHTMLBars: true,
@@ -91,13 +100,7 @@ module.exports = {
         ast: this.astPlugins()
       }
     };
-    // ensure we get a fresh templateCompilerModuleInstance per ember-addon
-    // instance NOTE: this is a quick hack, and will only work as long as
-    // templateCompilerPath is a single file bundle
-    //
-    // (╯°□°）╯︵ ɹǝqɯǝ
-    //
-    // we will also fix this in ember for future releases
+
     delete require.cache[templateCompilerPath];
     delete global.Ember;
     delete global.EmberENV;


### PR DESCRIPTION
We might not be the first to require the file here, and whoever last required it might have passed a different set of feature flags, etc (probably by mistake).

Deleting the cache before calling require ensures we are getting the fresh copy we are expecting.

We noticed this because ember-cli-htmlbars-inline-precompiler is [incorrectly requiring that file](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/pull/30) (which is a problem on its own), but this fix seems good to have regardless.