### PR TITLE
Provide `cacheKey` to enable cache-busting based on runtime config

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -123,9 +123,17 @@ module.exports = {
 
       plugins.push(wrapper.plugin);
 
-      if (typeof wrapper.baseDir === 'function') {
-        var pluginHashForDep = hashForDep(wrapper.baseDir());
-        cacheKeys.push(pluginHashForDep);
+      var providesBaseDir = typeof wrapper.baseDir === 'function';
+      var augmentsCacheKey = typeof wrapper.cacheKey === 'function';
+
+      if (providesBaseDir || augmentsCacheKey) {
+        if (providesBaseDir) {
+          var pluginHashForDep = hashForDep(wrapper.baseDir());
+          cacheKeys.push(pluginHashForDep);
+        }
+        if (augmentsCacheKey) {
+          cacheKeys.push(wrapper.cacheKey());
+        }
       } else {
         // support for ember-cli < 2.2.0
         var log = this.ui.writeDeprecateLine || this.ui.writeLine;


### PR DESCRIPTION
Hi,

So after #90 was merged ast-plugins could bust the cache based on directory changes, which is awesome and something addons like [ember-cli-conditional-compile](https://github.com/minichate/ember-cli-conditional-compile) has needed for a while. 

However like @rwjblue said in #90 it was made to work similarly to https://github.com/babel/broccoli-babel-transpiler/pull/89, which also includes a `cacheKey` method which augments the _cacheKeys_ based on runtime configurations rather than file-directory changes. 

It's a feature I would like to have so this is my attempt at implementing it for HTMLBars 🙏

I've been going through various PR's like #90, https://github.com/babel/broccoli-babel-transpiler/pull/89, https://github.com/ember-cli/babel-plugin-feature-flags/pull/12 and what [documentation I could find about it](https://github.com/babel/broccoli-babel-transpiler#caching) to get a grip on what it should do. 

So far I have tested it with [ember-cli-conditional-compile](https://github.com/minichate/ember-cli-conditional-compile) by registering the ast-plugin with `cacheKey` method returning its _featureFlags_ which are based on environment setup, and it's been working well so far. 

This is my first real contribution to Ember, so I might be out on deep waters, but feel free to modify or close the PR if I'm way off about this 😂 
