### PR TITLE
Ensure ember-template-compiler does not mutate shared config object.

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -73,7 +73,11 @@ module.exports = {
     // we will also fix this in ember for future releases
     delete require.cache[templateCompilerPath];
 
-    global.EmberENV = EmberENV; // Needed for eval time feature flag checks
+    // do a full clone of the EmberENV (it is guaranteed to be structured
+    // cloneable) to prevent ember-template-compiler.js from mutating
+    // the shared global config
+    let clonedEmberENV = JSON.parse(JSON.stringify(EmberENV));
+    global.EmberENV = clonedEmberENV; // Needed for eval time feature flag checks
     let pluginInfo = this.astPlugins();
 
     let htmlbarsOptions = {


### PR DESCRIPTION
During evaluation of EmberENV Ember internally mutates the object (setting defaults and whatnot). This change prevents the mutation from modifying the actual configuration embedded into the final assets.

Related to failing tests in ember-cli/ember-cli#7270.