### PR TITLE
Avoid require cache busting whenever possible.

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -108,13 +108,20 @@ module.exports = {
       toTree(tree) {
         let htmlbarsOptions = this._addon.htmlbarsOptions();
         let TemplateCompiler = require('./index');
+
         return new TemplateCompiler(tree, htmlbarsOptions);
       },
 
-      precompile(string) {
+      precompile(string, _options) {
         let htmlbarsOptions = this._addon.htmlbarsOptions();
         let templateCompiler = htmlbarsOptions.templateCompiler;
-        return utils.template(templateCompiler, string);
+
+        let options = Object.assign({}, _options, {
+          contents: string,
+          plugins: htmlbarsOptions.plugins,
+        });
+
+        return utils.template(templateCompiler, string, options);
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -35,26 +35,12 @@ class TemplateCompiler extends Filter {
     this.inputTree = inputTree;
 
     this.precompile = this.options.templateCompiler.precompile;
-    this.registerPlugin = this.options.templateCompiler.registerPlugin;
 
-    this.registerPlugins();
     this.initializeFeatures();
   }
 
   baseDir() {
     return __dirname;
-  }
-
-  registerPlugins() {
-    let plugins = this.options.plugins;
-
-    if (plugins) {
-      for (let type in plugins) {
-        for (let i = 0, l = plugins[type].length; i < l; i++) {
-          this.registerPlugin(type, plugins[type][i]);
-        }
-      }
-    }
   }
 
   initializeFeatures() {
@@ -76,7 +62,8 @@ class TemplateCompiler extends Filter {
     try {
       return 'export default ' + utils.template(this.options.templateCompiler, stripBom(string), {
         contents: string,
-        moduleName: relativePath
+        moduleName: relativePath,
+        plugins: this.options.plugins,
       }) + ';';
     } catch(error) {
       rethrowBuildError(error);

--- a/node-tests/purge-module-test.js
+++ b/node-tests/purge-module-test.js
@@ -1,10 +1,14 @@
 'use strict';
 
-const purgeModule = require('../ember-addon-main').purgeModule;
+const _purgeModule = require('../ember-addon-main').purgeModule;
 const expect = require('chai').expect;
 
 describe('purgeModule', function() {
   const FIXTURE_COMPILER_PATH = require.resolve('./fixtures/compiler');
+
+  function purgeModule(modulePath) {
+    return _purgeModule.call({}, modulePath);
+  }
 
   it('it works correctly', function() {
     expect(purgeModule('asdfasdfasdfaf-unknown-file')).to.eql(undefined);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "broccoli-persistent-filter": "^2.1.0",
+    "ember-cli-version-checker": "^2.1.2",
     "hash-for-dep": "^1.2.3",
     "json-stable-stringify": "^1.0.1",
     "strip-bom": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "broccoli-merge-trees": "^3.0.1",
     "broccoli-test-helper": "^1.5.0",
     "chai": "^4.2.0",
     "co": "^4.6.0",


### PR DESCRIPTION
Generally speaking, ember-cli allows each "addon layer" in the app that is transpiling its own templates. Each layer is _supposed_ to be able to provide its own AST plugins without affecting the others. Unfortunately, the implementation of `Ember.HTMLBars.registerPlugin` mutates a single shared module scope array to track which plugins should be ran. 

In order to allow the layered approach mentioned above, ember-cli-htmlbars was forced to invalidate the `require.cache` and `delete` various things off of the `global` object. Requiring `ember-template-compiler.js` (~1.2mb) many times (once for the project and again _for each_ addon that depends on `ember-cli-htmlbars`) is a non-trivial percentage of every app's build time and overall memory.

This PR begins the process of _removing_ that manual cache invalidation, in favor of better APIs provided by Ember (as of Ember 1.13 and higher).

In order to stop the manual cache invalidation but still provide the guarantees that each layer's AST plugins do not affect the others' we must still continue to invalidate the caches cache busting system if we detect that **anyone** in the system is using the global state mutation.

---

Specific changes in this PR:

* Add a test that shows the failure mode of "leaking" AST plugins in global module state.
* Update the compilation code to avoid leveraging global state mutation (e.g. don't use `Ember.HTMLBars.registerPlugin`), instead pass the plugins directly to `Ember.HTMLBars.precompile` for each module.
* Fallback to manual cache invalidation if we detect that _any_ addon in the system is using an older version of `ember-cli-htmlbars` or `ember-cli-htmlbars-inline-precompile` that still uses global state mutation.
* Avoid purging the `require.cache` when the requirements are met.

TODOs:

- [x] PR review
- [ ] detect Ember version and properly shim the AST plugins into the correct format (we need to prevent Ember from doing manual shimming/wrapping for _each_ template compilation)

Future PR TODO:

- [ ] Make similar changes to ember-cli-htmlbars-inline-precompile