### PR TITLE
AST plugin cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ module.exports = {
     // called within htmlbars when compiling a given template).
     this.app.registry.add('htmlbars-ast-plugin', {
       name: 'some-transform',
-      plugin: SomeTransform
+      plugin: SomeTransform,
+      cacheKey: function() {
+        // Invoked once per process.
+        // Usually used to return a value representing configuration that
+        // affects the behavior of the transform.
+        // Can return any value that can be represented in JSON.
+      },
+      templateCacheKey: function(relativePathToTemplate) {
+        // Invoked every time the template might need to be (re-)compiled.
+        // Used to invalidate the compiled template if the output depends on
+        // application content that isn't part of the template itself.
+        // Must return a string.
+      }
     });
   }
 };

--- a/index.js
+++ b/index.js
@@ -86,10 +86,14 @@ class TemplateCompiler extends Filter {
   }
 
   processString(string, relativePath) {
+    let srcDir = this.inputPaths[0];
     try {
       return 'export default ' + utils.template(this.options.templateCompiler, stripBom(string), {
         contents: string,
-        moduleName: relativePath
+        moduleName: relativePath,
+        parseOptions: {
+          srcName: path.join(srcDir, relativePath)
+        }
       }) + ';';
     } catch(error) {
       rethrowBuildError(error);

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class TemplateCompiler extends Filter {
 
     this.precompile = this.options.templateCompiler.precompile;
     this.registerPlugin = this.options.templateCompiler.registerPlugin;
+    this.unregisterPlugin = this.options.templateCompiler.unregisterPlugin
 
     this.registerPlugins();
     this.initializeFeatures();
@@ -53,6 +54,17 @@ class TemplateCompiler extends Filter {
       for (let type in plugins) {
         for (let i = 0, l = plugins[type].length; i < l; i++) {
           this.registerPlugin(type, plugins[type][i]);
+        }
+      }
+    }
+  }
+  unregisterPlugins() {
+    let plugins = this.options.plugins;
+
+    if (plugins) {
+      for (let type in plugins) {
+        for (let i = 0, l = plugins[type].length; i < l; i++) {
+          this.unregisterPlugin(type, plugins[type][i]);
         }
       }
     }

--- a/node-tests/ast_plugins_test.js
+++ b/node-tests/ast_plugins_test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const TemplateCompiler = require('../index');
+const co = require('co');
+const { createTempDir, createBuilder } = require('broccoli-test-helper');
+const fixturify = require('fixturify');
+
+describe('AST plugins', function(){
+  const they = it;
+  this.timeout(10000);
+
+  let input, output, builder, tree, htmlbarsOptions;
+
+  beforeEach(co.wrap(function*() {
+    templateCacheKeyState = 0;
+    rewriterCallCount = 0;
+    input = yield createTempDir();
+    input.write(fixturify.readSync(`${__dirname}/fixtures`));
+    htmlbarsOptions = {
+      isHTMLBars: true,
+      templateCompiler: require('ember-source/dist/ember-template-compiler.js')
+    };
+  }));
+
+  afterEach(co.wrap(function*() {
+    if (tree) {
+      tree.unregisterPlugins();
+      yield tree.processor.processor._cache.clear();
+    }
+
+    if (builder) {
+      builder.cleanup();
+    }
+
+    yield input.dispose();
+
+    if (output) {
+      yield output.dispose();
+    }
+  }));
+
+  let templateCacheKeyState, rewriterCallCount;
+  const DivRewriter = {
+    name: "test-div-rewriter",
+    visitor: {
+      Program(node) {
+        let basename = node.loc.source && path.basename(node.loc.source);
+        if (basename && basename === "template.hbs") {
+          console.dir(node);
+          rewriterCallCount++;
+        }
+      },
+      ElementNode(node) {
+        if (node.tag === "div") {
+          node.tag = "span-"+templateCacheKeyState;
+        }
+      }
+    }
+  }
+
+
+  they('are accepted and used.', co.wrap(function* () {
+    htmlbarsOptions.plugins = {
+      ast: [() => DivRewriter]
+    };
+
+    tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+
+    output = createBuilder(tree);
+    yield output.build();
+
+    let templateOutput = output.readText('template.js');
+    assert.ok(!templateOutput.match(/div/));
+    assert.ok(templateOutput.match(/span-0/));
+    assert.strictEqual(rewriterCallCount, 1);
+  }));
+
+  they('will bust the hot cache if the template cache key changes.', co.wrap(function* () {
+    Object.assign(htmlbarsOptions, {
+      plugins: {
+        ast: [() => DivRewriter]
+      },
+      templateCacheKey(relativePath) {
+        let key = relativePath + ":" + templateCacheKeyState;
+        console.log("template cache key is", key);
+        return key;
+      }
+    });
+
+    tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+
+    output = createBuilder(tree);
+    yield output.build();
+    let templateOutput = output.readText('template.js');
+    assert.ok(!templateOutput.match(/div/));
+    assert.ok(templateOutput.match(/span-0/));
+    assert.strictEqual(rewriterCallCount, 1);
+
+    // The state didn't change. the output should be cached
+    // and the rewriter shouldn't be invoked.
+    yield output.build();
+    templateOutput = output.readText('template.js');
+    assert.ok(!templateOutput.match(/div/));
+    assert.ok(templateOutput.match(/span-0/));
+    assert.strictEqual(rewriterCallCount, 1);
+
+    // The state changes. the cache key updates and the template
+    // should be recompiled.
+    templateCacheKeyState++;
+    assert.strictEqual(htmlbarsOptions.templateCacheKey("foo"), "foo:1");
+    yield output.build();
+    templateOutput = output.readText('template.js');
+    // XXX This fails because the hot cache is not invalidated when the cache
+    // XXX key changes.
+    assert.strictEqual(rewriterCallCount, 2);
+    assert.ok(templateOutput.match(/span-1/));
+  }));
+
+  they('will bust the persistent cache if the template cache key changes.', co.wrap(function* () {
+    Object.assign(htmlbarsOptions, {
+      plugins: {
+        ast: [() => DivRewriter]
+      },
+      templateCacheKey(relativePath) {
+        let key = relativePath + ":" + templateCacheKeyState;
+        console.log("template cache key is", key);
+        return key;
+      }
+    });
+
+    tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+
+    output = createBuilder(tree);
+    yield output.build();
+    let templateOutput = output.readText('template.js');
+    assert.ok(!templateOutput.match(/div/));
+    assert.ok(templateOutput.match(/span-0/));
+    assert.strictEqual(rewriterCallCount, 1);
+    yield output.dispose();
+    tree.unregisterPlugins();
+
+    // The state didn't change. the output should be cached
+    // and the rewriter shouldn't be invoked.
+    tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+    output = createBuilder(tree);
+    yield output.build();
+    templateOutput = output.readText('template.js');
+    assert.ok(!templateOutput.match(/div/));
+    assert.ok(templateOutput.match(/span-0/));
+    assert.strictEqual(rewriterCallCount, 1);
+    yield output.dispose();
+    tree.unregisterPlugins();
+
+    // The state changes. the cache key updates and the template
+    // should be recompiled.
+    templateCacheKeyState++;
+    assert.strictEqual(htmlbarsOptions.templateCacheKey("foo"), "foo:1");
+    tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+    output = createBuilder(tree);
+    yield output.build();
+    templateOutput = output.readText('template.js');
+    assert.strictEqual(rewriterCallCount, 2);
+    assert.ok(templateOutput.match(/span-1/));
+    assert.strictEqual(rewriterCallCount, 2);
+  }));
+});


### PR DESCRIPTION
The main goal for this PR is to add a mechanism to invalidate a template's cache based on state that is specific to that template. My use case for this feature is that I am rewriting a template's css classes based on information that I derive from css files, when those css files change, the templates that consume the styles may also need to change.

This PR will close https://github.com/ember-cli/ember-cli-htmlbars/issues/227.

A new option for ast plugins is created which I have named `templateCacheKey` that is a function that accepts a path and returns a cache key. When the cache key changes, the template should be recompiled during the next build.

This is a draft, to get early feedback on the code so far. The following issues need to be resolved before this PR is ready for final review:

- [x] Add tests for ast plugins and the new cache invalidation behavior.
- [x] Cache invalidation for warm builds.
- [ ] Cache invalidation for rebuilds. Currently the template itself has to have a change detected by `fs-tree-diff` for the template to be recompiled. I contend this is best handled by `broccoli-persistent-filter` due using the existing `cacheKeyProcessString` method that this addon implements.
- [ ] Ensure that the path passed to the cache invalidation code has sufficient context to uniquely identify the template within the application and that there's agreement with ember's internal identifiers for those templates.

While working on this, I noticed that handlebar AST nodes do not have their source location set because this addon wasn't setting the right option for it, so I've added support for that as part of this PR.

I've also exposed plugin unregistration because I needed to do that in the unit tests for ast plugins.