### PR TITLE
Implement inline precompilation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
          - ember-canary
          - ember-default
          - ember-default-with-jquery
+         - with-ember-cli-htmlbars-inline-precompile
 
     steps:
     - uses: actions/checkout@v1

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -102,6 +102,14 @@ module.exports = function() {
           },
         },
         {
+          name: 'with-ember-cli-htmlbars-inline-precompile',
+          npm: {
+            devDependencies: {
+              'ember-cli-htmlbars-inline-precompile': '^2.1.0',
+            },
+          },
+        },
+        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    throwUnlessParallelizable: true,
   });
 
   /*

--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -54,19 +54,20 @@ module.exports = {
       if (pluginInfo.canParallelize) {
         logger.debug('using parallel API with for babel inline precompilation plugin');
 
+        // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
+        // only add ember-cli-htmlbars here
+        let modules = {
+          'ember-cli-htmlbars': 'hbs',
+          'ember-cli-htmlbars-inline-precompile': 'default',
+          'htmlbars-inline-precompile': 'default',
+        };
         let parallelBabelInfo = {
           requireFile: path.join(__dirname, 'require-from-worker'),
           buildUsing: 'build',
           params: {
             templateCompilerPath,
             parallelConfigs: pluginInfo.parallelConfigs,
-            // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
-            // only add ember-cli-htmlbars here
-            modulePaths: [
-              'ember-cli-htmlbars',
-              'ember-cli-htmlbars-inline-precompile',
-              'htmlbars-inline-precompile',
-            ],
+            modules,
           },
         };
 
@@ -95,16 +96,17 @@ module.exports = {
 
         logger.debug('Prevented by these plugins: ' + blockingPlugins);
 
+        // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
+        // only add ember-cli-htmlbars here
+        let modules = {
+          'ember-cli-htmlbars': 'hbs',
+          'ember-cli-htmlbars-inline-precompile': 'default',
+          'htmlbars-inline-precompile': 'default',
+        };
         let htmlBarsPlugin = utils.setup(pluginInfo, {
           projectConfig: this.projectConfig(),
           templateCompilerPath,
-          // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
-          // only add ember-cli-htmlbars here
-          modulePaths: [
-            'ember-cli-htmlbars',
-            'ember-cli-htmlbars-inline-precompile',
-            'htmlbars-inline-precompile',
-          ],
+          modules,
         });
 
         babelPlugins.push(htmlBarsPlugin);
@@ -116,7 +118,7 @@ module.exports = {
    * This function checks if 'ember-cli-htmlbars-inline-precompile' is already present in babelPlugins.
    * The plugin object will be different for non parallel API and parallel API.
    * For parallel api, check the `baseDir` of a plugin to see if it has current dirname
-   * For non parallel api, check the 'modulePaths' to see if it contains 'ember-cli-htmlbars-inline-precompile'
+   * For non parallel api, check the 'modules' to see if it contains the babel plugin
    * @param {*} plugins
    */
   _isBabelPluginRegistered(plugins) {

--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -2,38 +2,13 @@
 
 const path = require('path');
 const utils = require('./utils');
-const addDependencyTracker = require('./addDependencyTracker');
-const hashForDep = require('hash-for-dep');
+const debugGenerator = require('heimdalljs-logger');
+const logger = debugGenerator('ember-cli-htmlbars');
 
 module.exports = {
   name: require('../package').name,
 
   parentRegistry: null,
-
-  purgeModule(templateCompilerPath) {
-    // ensure we get a fresh templateCompilerModuleInstance per ember-addon
-    // instance NOTE: this is a quick hack, and will only work as long as
-    // templateCompilerPath is a single file bundle
-    //
-    // (╯°□°）╯︵ ɹǝqɯǝ
-    //
-    // we will also fix this in ember for future releases
-
-    // Module will be cached in .parent.children as well. So deleting from require.cache alone is not sufficient.
-    let mod = require.cache[templateCompilerPath];
-    if (mod && mod.parent) {
-      let index = mod.parent.children.indexOf(mod);
-      if (index >= 0) {
-        mod.parent.children.splice(index, 1);
-      } else {
-        throw new TypeError(
-          `ember-cli-htmlbars attempted to purge '${templateCompilerPath}' but something went wrong.`
-        );
-      }
-    }
-
-    delete require.cache[templateCompilerPath];
-  },
 
   setupPreprocessorRegistry(type, registry) {
     // ensure that broccoli-ember-hbs-template-compiler is not processing hbs files
@@ -61,8 +36,113 @@ module.exports = {
     }
   },
 
+  included() {
+    this._super.included.apply(this, arguments);
+
+    let addonOptions = this._getAddonOptions();
+    addonOptions.babel = addonOptions.babel || {};
+    addonOptions.babel.plugins = addonOptions.babel.plugins || [];
+    let babelPlugins = addonOptions.babel.plugins;
+
+    // add the babel-plugin-htmlbars-inline-precompile to the list of plugins
+    // used by `ember-cli-babel` addon
+    if (!this._isBabelPluginRegistered(babelPlugins)) {
+      let pluginWrappers = this.astPlugins();
+      let templateCompilerPath = this.templateCompilerPath();
+      let pluginInfo = utils.setupPlugins(pluginWrappers);
+
+      if (pluginInfo.canParallelize) {
+        logger.debug('using parallel API with for babel inline precompilation plugin');
+
+        let parallelBabelInfo = {
+          requireFile: path.join(__dirname, 'require-from-worker'),
+          buildUsing: 'build',
+          params: {
+            templateCompilerPath,
+            parallelConfigs: pluginInfo.parallelConfigs,
+            // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
+            // only add ember-cli-htmlbars here
+            modulePaths: [
+              'ember-cli-htmlbars',
+              'ember-cli-htmlbars-inline-precompile',
+              'htmlbars-inline-precompile',
+            ],
+          },
+        };
+
+        // parallelBabelInfo will not be used in the cache unless it is explicitly included
+        let cacheKey = utils.makeCacheKey(
+          templateCompilerPath,
+          pluginInfo,
+          JSON.stringify(parallelBabelInfo)
+        );
+
+        babelPlugins.push({
+          _parallelBabel: parallelBabelInfo,
+          baseDir: () => __dirname,
+          cacheKey: () => cacheKey,
+        });
+      } else {
+        logger.debug('NOT using parallel API with for babel inline precompilation plugin');
+
+        let blockingPlugins = pluginWrappers
+          .map(wrapper => {
+            if (wrapper.parallelBabel === undefined) {
+              return wrapper.name;
+            }
+          })
+          .filter(Boolean);
+
+        logger.debug('Prevented by these plugins: ' + blockingPlugins);
+
+        let htmlBarsPlugin = utils.setup(pluginInfo, {
+          projectConfig: this.projectConfig(),
+          templateCompilerPath,
+          // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
+          // only add ember-cli-htmlbars here
+          modulePaths: [
+            'ember-cli-htmlbars',
+            'ember-cli-htmlbars-inline-precompile',
+            'htmlbars-inline-precompile',
+          ],
+        });
+
+        babelPlugins.push(htmlBarsPlugin);
+      }
+    }
+  },
+
+  /**
+   * This function checks if 'ember-cli-htmlbars-inline-precompile' is already present in babelPlugins.
+   * The plugin object will be different for non parallel API and parallel API.
+   * For parallel api, check the `baseDir` of a plugin to see if it has current dirname
+   * For non parallel api, check the 'modulePaths' to see if it contains 'ember-cli-htmlbars-inline-precompile'
+   * @param {*} plugins
+   */
+  _isBabelPluginRegistered(plugins) {
+    return plugins.some(plugin => {
+      if (Array.isArray(plugin)) {
+        return plugin[0] === require.resolve('babel-plugin-htmlbars-inline-precompile');
+      } else if (
+        plugin !== null &&
+        typeof plugin === 'object' &&
+        plugin._parallelBabel !== undefined
+      ) {
+        return (
+          plugin._parallelBabel.requireFile === path.resolve(__dirname, 'lib/require-from-worker')
+        );
+      } else {
+        return false;
+      }
+    });
+  },
+
   projectConfig() {
     return this.project.config(process.env.EMBER_ENV);
+  },
+
+  _getAddonOptions() {
+    return (this.parent && this.parent.options) || (this.app && this.app.options) || {};
   },
 
   templateCompilerPath() {
@@ -88,78 +168,15 @@ module.exports = {
 
   htmlbarsOptions() {
     let projectConfig = this.projectConfig() || {};
-    let EmberENV = projectConfig.EmberENV || {};
     let templateCompilerPath = this.templateCompilerPath();
-
-    this.purgeModule(templateCompilerPath);
-
-    // do a full clone of the EmberENV (it is guaranteed to be structured
-    // cloneable) to prevent ember-template-compiler.js from mutating
-    // the shared global config
-    let clonedEmberENV = JSON.parse(JSON.stringify(EmberENV));
-    global.EmberENV = clonedEmberENV; // Needed for eval time feature flag checks
     let pluginInfo = this.astPlugins();
 
-    let htmlbarsOptions = {
-      isHTMLBars: true,
-      EmberENV: EmberENV,
-      templateCompiler: require(templateCompilerPath),
-      templateCompilerPath: templateCompilerPath,
-
-      plugins: {
-        ast: pluginInfo.plugins,
-      },
-
-      dependencyInvalidation: pluginInfo.dependencyInvalidation,
-
-      pluginCacheKey: pluginInfo.cacheKeys,
-    };
-
-    this.purgeModule(templateCompilerPath);
-
-    delete global.Ember;
-    delete global.EmberENV;
-
-    return htmlbarsOptions;
+    return utils.buildOptions(projectConfig, templateCompilerPath, pluginInfo);
   },
 
   astPlugins() {
     let pluginWrappers = this.parentRegistry.load('htmlbars-ast-plugin');
-    let plugins = [];
-    let cacheKeys = [];
-    let dependencyInvalidation = false;
 
-    for (let i = 0; i < pluginWrappers.length; i++) {
-      let wrapper = pluginWrappers[i];
-      dependencyInvalidation = dependencyInvalidation || wrapper.dependencyInvalidation;
-      plugins.push(addDependencyTracker(wrapper.plugin, wrapper.dependencyInvalidation));
-
-      let providesBaseDir = typeof wrapper.baseDir === 'function';
-      let augmentsCacheKey = typeof wrapper.cacheKey === 'function';
-
-      if (providesBaseDir || augmentsCacheKey || wrapper.dependencyInvalidation) {
-        if (providesBaseDir) {
-          let pluginHashForDep = hashForDep(wrapper.baseDir());
-          cacheKeys.push(pluginHashForDep);
-        }
-        if (augmentsCacheKey) {
-          cacheKeys.push(wrapper.cacheKey());
-        }
-      } else {
-        // support for ember-cli < 2.2.0
-        this.ui.writeDeprecateLine(
-          'ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `' +
-            wrapper.name +
-            '`.'
-        );
-        cacheKeys.push(new Date().getTime() + '|' + Math.random());
-      }
-    }
-
-    return {
-      plugins: plugins,
-      cacheKeys: cacheKeys,
-      dependencyInvalidation: dependencyInvalidation,
-    };
+    return utils.setupPlugins(pluginWrappers);
   },
 };

--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -51,16 +51,21 @@ module.exports = {
       let templateCompilerPath = this.templateCompilerPath();
       let pluginInfo = utils.setupPlugins(pluginWrappers);
 
+      let modules = {
+        'ember-cli-htmlbars': 'hbs',
+      };
+
+      // TODO: add deprecation to migrate import paths to use
+      // ember-cli-htmlbars instead of htmlbars-inline-precompile or
+      // ember-cli-htmlbars-inline-precompile
+      if (!this.parent.addons.find(a => a.name === 'ember-cli-htmlbars-inline-precompile')) {
+        modules['ember-cli-htmlbars-inline-precompile'] = 'default';
+        modules['htmlbars-inline-precompile'] = 'default';
+      }
+
       if (pluginInfo.canParallelize) {
         logger.debug('using parallel API with for babel inline precompilation plugin');
 
-        // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
-        // only add ember-cli-htmlbars here
-        let modules = {
-          'ember-cli-htmlbars': 'hbs',
-          'ember-cli-htmlbars-inline-precompile': 'default',
-          'htmlbars-inline-precompile': 'default',
-        };
         let parallelBabelInfo = {
           requireFile: path.join(__dirname, 'require-from-worker'),
           buildUsing: 'build',
@@ -96,13 +101,6 @@ module.exports = {
 
         logger.debug('Prevented by these plugins: ' + blockingPlugins);
 
-        // TODO: detect the presence of ember-cli-htmlbars-inline-precompile and if present
-        // only add ember-cli-htmlbars here
-        let modules = {
-          'ember-cli-htmlbars': 'hbs',
-          'ember-cli-htmlbars-inline-precompile': 'default',
-          'htmlbars-inline-precompile': 'default',
-        };
         let htmlBarsPlugin = utils.setup(pluginInfo, {
           projectConfig: this.projectConfig(),
           templateCompilerPath,

--- a/lib/require-from-worker.js
+++ b/lib/require-from-worker.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const utils = require('./utils');
+let astPlugin = {};
+
+module.exports = {
+  build(options, cacheKey) {
+    // Caching the plugin info so that call to setup functions will be made once per worker
+    // and not once per module tranformation
+    let plugin = astPlugin[cacheKey];
+    if (!plugin) {
+      const pluginInfo = utils.setupPlugins(options.parallelConfigs);
+
+      plugin = utils.setup(pluginInfo, options);
+
+      // if cacheKey is not undefined cache it.
+      if (cacheKey) {
+        astPlugin[cacheKey] = plugin;
+      }
+    }
+    return plugin;
+  },
+};

--- a/lib/template-compiler-plugin.js
+++ b/lib/template-compiler-plugin.js
@@ -37,16 +37,23 @@ class TemplateCompiler extends Filter {
     this.options = options;
     this.inputTree = inputTree;
 
+    // TODO: do we need this?
     this.precompile = this.options.templateCompiler.precompile;
-    this.registerPlugin = this.options.templateCompiler.registerPlugin;
-    this.unregisterPlugin = this.options.templateCompiler.unregisterPlugin;
 
-    this.registerPlugins();
-    this.initializeFeatures();
+    let { templateCompiler, plugins, EmberENV } = options;
+
+    utils.registerPlugins(templateCompiler, plugins);
+    utils.initializeEmberENV(templateCompiler, EmberENV);
   }
 
   baseDir() {
     return __dirname;
+  }
+
+  unregisterPlugins() {
+    let { templateCompiler, plugins } = this.options;
+
+    utils.unregisterPlugins(templateCompiler, plugins);
   }
 
   registeredASTPlugins() {
@@ -54,46 +61,6 @@ class TemplateCompiler extends Filter {
     // it also returns other plugins that are registered by ember itself.
     let options = this.options.templateCompiler.compileOptions();
     return (options.plugins && options.plugins.ast) || [];
-  }
-
-  registerPlugins() {
-    let plugins = this.options.plugins;
-
-    if (plugins) {
-      for (let type in plugins) {
-        for (let i = 0, l = plugins[type].length; i < l; i++) {
-          this.registerPlugin(type, plugins[type][i]);
-        }
-      }
-    }
-  }
-  unregisterPlugins() {
-    let plugins = this.options.plugins;
-
-    if (plugins) {
-      for (let type in plugins) {
-        for (let i = 0, l = plugins[type].length; i < l; i++) {
-          this.unregisterPlugin(type, plugins[type][i]);
-        }
-      }
-    }
-  }
-
-  initializeFeatures() {
-    let EmberENV = this.options.EmberENV;
-    let FEATURES = this.options.FEATURES;
-    let templateCompiler = this.options.templateCompiler;
-
-    if (FEATURES) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Using `options.FEATURES` with ember-cli-htmlbars is deprecated.  Please provide the full EmberENV as options.EmberENV instead.'
-      );
-      EmberENV = EmberENV || {};
-      EmberENV.FEATURES = FEATURES;
-    }
-
-    utils.initializeEmberENV(templateCompiler, EmberENV);
   }
 
   processString(string, relativePath) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,36 +1,220 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+const HTMLBarsInlinePrecompilePlugin = require.resolve('babel-plugin-htmlbars-inline-precompile');
+const hashForDep = require('hash-for-dep');
+const debugGenerator = require('heimdalljs-logger');
+const logger = debugGenerator('ember-cli-htmlbars');
+const addDependencyTracker = require('./addDependencyTracker');
+
+function buildOptions(projectConfig, templateCompilerPath, pluginInfo) {
+  let EmberENV = projectConfig.EmberENV || {};
+
+  purgeModule(templateCompilerPath);
+
+  // do a full clone of the EmberENV (it is guaranteed to be structured
+  // cloneable) to prevent ember-template-compiler.js from mutating
+  // the shared global config
+  let clonedEmberENV = JSON.parse(JSON.stringify(EmberENV));
+  global.EmberENV = clonedEmberENV; // Needed for eval time feature flag checks
+
+  let htmlbarsOptions = {
+    isHTMLBars: true,
+    EmberENV: EmberENV,
+    templateCompiler: require(templateCompilerPath),
+    templateCompilerPath: templateCompilerPath,
+
+    plugins: {
+      ast: pluginInfo.plugins,
+    },
+
+    dependencyInvalidation: pluginInfo.dependencyInvalidation,
+
+    pluginCacheKey: pluginInfo.cacheKeys,
+  };
+
+  purgeModule(templateCompilerPath);
+
+  delete global.Ember;
+  delete global.EmberENV;
+
+  return htmlbarsOptions;
+}
+
+function purgeModule(templateCompilerPath) {
+  // ensure we get a fresh templateCompilerModuleInstance per ember-addon
+  // instance NOTE: this is a quick hack, and will only work as long as
+  // templateCompilerPath is a single file bundle
+  //
+  // (╯°□°）╯︵ ɹǝqɯǝ
+  //
+  // we will also fix this in ember for future releases
+
+  // Module will be cached in .parent.children as well. So deleting from require.cache alone is not sufficient.
+  let mod = require.cache[templateCompilerPath];
+  if (mod && mod.parent) {
+    let index = mod.parent.children.indexOf(mod);
+    if (index >= 0) {
+      mod.parent.children.splice(index, 1);
+    } else {
+      throw new TypeError(
+        `ember-cli-htmlbars attempted to purge '${templateCompilerPath}' but something went wrong.`
+      );
+    }
+  }
+
+  delete require.cache[templateCompilerPath];
+}
+
+function registerPlugins(templateCompiler, plugins) {
+  if (plugins) {
+    for (let type in plugins) {
+      for (let i = 0, l = plugins[type].length; i < l; i++) {
+        templateCompiler.registerPlugin(type, plugins[type][i]);
+      }
+    }
+  }
+}
+
+function unregisterPlugins(templateCompiler, plugins) {
+  if (plugins) {
+    for (let type in plugins) {
+      for (let i = 0, l = plugins[type].length; i < l; i++) {
+        templateCompiler.unregisterPlugin(type, plugins[type][i]);
+      }
+    }
+  }
+}
+
+function initializeEmberENV(templateCompiler, EmberENV) {
+  if (!templateCompiler || !EmberENV) {
+    return;
+  }
+
+  let props;
+
+  if (EmberENV.FEATURES) {
+    props = Object.keys(EmberENV.FEATURES);
+
+    props.forEach(prop => {
+      templateCompiler._Ember.FEATURES[prop] = EmberENV.FEATURES[prop];
+    });
+  }
+
+  if (EmberENV) {
+    props = Object.keys(EmberENV);
+
+    props.forEach(prop => {
+      if (prop === 'FEATURES') {
+        return;
+      }
+
+      templateCompiler._Ember.ENV[prop] = EmberENV[prop];
+    });
+  }
+}
+
+function template(templateCompiler, string, options) {
+  let precompiled = templateCompiler.precompile(string, options);
+  return 'Ember.HTMLBars.template(' + precompiled + ')';
+}
+
+function setup(pluginInfo, options) {
+  // borrowed from ember-cli-htmlbars http://git.io/vJDrW
+  let projectConfig = options.projectConfig || {};
+  let templateCompilerPath = options.templateCompilerPath;
+
+  let htmlbarsOptions = buildOptions(projectConfig, templateCompilerPath, pluginInfo);
+  let { templateCompiler } = htmlbarsOptions;
+
+  let cacheKey = makeCacheKey(templateCompilerPath, pluginInfo);
+
+  registerPlugins(templateCompiler, pluginInfo.plugins);
+
+  let { precompile } = templateCompiler;
+  precompile.baseDir = () => path.resolve(__dirname, '..');
+  precompile.cacheKey = () => cacheKey;
+
+  let precompileInlineHTMLBarsPlugin = [
+    HTMLBarsInlinePrecompilePlugin,
+    { precompile, modulePaths: options.modulePaths },
+  ];
+
+  return precompileInlineHTMLBarsPlugin;
+}
+
+function makeCacheKey(templateCompilerPath, pluginInfo, extra) {
+  let templateCompilerFullPath = require.resolve(templateCompilerPath);
+  let templateCompilerCacheKey = fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' });
+  let cacheItems = [templateCompilerCacheKey, extra].concat(pluginInfo.cacheKeys.sort());
+  // extra may be undefined
+  return cacheItems.filter(Boolean).join('|');
+}
+
+function setupPlugins(wrappers) {
+  let plugins = [];
+  let cacheKeys = [];
+  let parallelConfigs = [];
+  let dependencyInvalidation = false;
+  let canParallelize = true;
+
+  for (let i = 0; i < wrappers.length; i++) {
+    let wrapper = wrappers[i];
+
+    if (wrapper.requireFile) {
+      const plugin = require(wrapper.requireFile);
+      wrapper = plugin[wrapper.buildUsing](wrapper.params);
+    }
+
+    if (wrapper.parallelBabel) {
+      parallelConfigs.push(wrapper.parallelBabel);
+    } else {
+      canParallelize = false;
+    }
+
+    dependencyInvalidation = dependencyInvalidation || wrapper.dependencyInvalidation;
+    plugins.push(addDependencyTracker(wrapper.plugin, wrapper.dependencyInvalidation));
+
+    let providesBaseDir = typeof wrapper.baseDir === 'function';
+    let augmentsCacheKey = typeof wrapper.cacheKey === 'function';
+
+    // TODO: investigate if `wrapper.dependencyInvalidation` should actually prevent the warning
+    if (providesBaseDir || augmentsCacheKey || wrapper.dependencyInvalidation) {
+      if (providesBaseDir) {
+        let pluginHashForDep = hashForDep(wrapper.baseDir());
+        cacheKeys.push(pluginHashForDep);
+      }
+      if (augmentsCacheKey) {
+        cacheKeys.push(wrapper.cacheKey());
+      }
+    } else {
+      logger.debug(
+        'ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `' +
+          wrapper.name +
+          '`.'
+      );
+      cacheKeys.push(new Date().getTime() + '|' + Math.random());
+    }
+  }
+
+  return {
+    plugins,
+    cacheKeys,
+    parallelConfigs,
+    canParallelize,
+    hasDependencyInvalidation: !!dependencyInvalidation,
+  };
+}
+
 module.exports = {
-  initializeEmberENV(templateCompiler, EmberENV) {
-    if (!templateCompiler || !EmberENV) {
-      return;
-    }
-
-    let props;
-
-    if (EmberENV.FEATURES) {
-      props = Object.keys(EmberENV.FEATURES);
-
-      props.forEach(prop => {
-        templateCompiler._Ember.FEATURES[prop] = EmberENV.FEATURES[prop];
-      });
-    }
-
-    if (EmberENV) {
-      props = Object.keys(EmberENV);
-
-      props.forEach(prop => {
-        if (prop === 'FEATURES') {
-          return;
-        }
-
-        templateCompiler._Ember.ENV[prop] = EmberENV[prop];
-      });
-    }
-  },
-
-  template(templateCompiler, string, options) {
-    let precompiled = templateCompiler.precompile(string, options);
-    return 'Ember.HTMLBars.template(' + precompiled + ')';
-  },
+  buildOptions,
+  purgeModule,
+  registerPlugins,
+  unregisterPlugins,
+  initializeEmberENV,
+  template,
+  setup,
+  makeCacheKey,
+  setupPlugins,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -138,7 +138,7 @@ function setup(pluginInfo, options) {
 
   let precompileInlineHTMLBarsPlugin = [
     HTMLBarsInlinePrecompilePlugin,
-    { precompile, modulePaths: options.modulePaths },
+    { precompile, modules: options.modules },
   ];
 
   return precompileInlineHTMLBarsPlugin;

--- a/node-tests/purge-module-test.js
+++ b/node-tests/purge-module-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const purgeModule = require('../lib/ember-addon-main').purgeModule;
+const purgeModule = require('../lib/utils').purgeModule;
 const expect = require('chai').expect;
 
 describe('purgeModule', function() {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "test:node:debug": "mocha debug node-tests/*.js"
   },
   "dependencies": {
+    "babel-plugin-htmlbars-inline-precompile": "^2.0.0",
     "broccoli-persistent-filter": "^2.3.1",
     "hash-for-dep": "^1.5.1",
+    "heimdalljs-logger": "^0.1.10",
     "json-stable-stringify": "^1.0.1",
     "strip-bom": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:node:debug": "mocha debug node-tests/*.js"
   },
   "dependencies": {
-    "babel-plugin-htmlbars-inline-precompile": "^2.0.0",
+    "babel-plugin-htmlbars-inline-precompile": "^2.1.0",
     "broccoli-persistent-filter": "^2.3.1",
     "hash-for-dep": "^1.5.1",
     "heimdalljs-logger": "^0.1.10",

--- a/tests/integration/components/test-inline-precompile-test.js
+++ b/tests/integration/components/test-inline-precompile-test.js
@@ -3,8 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbsOne from 'htmlbars-inline-precompile';
 import hbsTwo from 'ember-cli-htmlbars-inline-precompile';
-// TODO: fix this to import a named export
-import hbsThree from 'ember-cli-htmlbars';
+import { hbs as hbsThree } from 'ember-cli-htmlbars';
 
 module('tests/integration/components/test-inline-precompile', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/test-inline-precompile-test.js
+++ b/tests/integration/components/test-inline-precompile-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbsOne from 'htmlbars-inline-precompile';
+import hbsTwo from 'ember-cli-htmlbars-inline-precompile';
+import { hbs as hbsThree } from 'ember-cli-htmlbars';
+
+module('tests/integration/components/test-inline-precompile', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('htmlbars-inline-precompile works', async function(assert) {
+    await render(hbsOne`Wheeeee`);
+
+    assert.equal(this.element.textContent.trim(), 'Wheeeee');
+  });
+
+  test('ember-cli-htmlbars-inline-precompile works', async function(assert) {
+    await render(hbsTwo`Wheeeee`);
+
+    assert.equal(this.element.textContent.trim(), 'Wheeeee');
+  });
+
+  test('ember-cli-htmlbars works', async function(assert) {
+    await render(hbsThree`Wheeeee`);
+
+    assert.equal(this.element.textContent.trim(), 'Wheeeee');
+  });
+});

--- a/tests/integration/components/test-inline-precompile-test.js
+++ b/tests/integration/components/test-inline-precompile-test.js
@@ -3,7 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbsOne from 'htmlbars-inline-precompile';
 import hbsTwo from 'ember-cli-htmlbars-inline-precompile';
-import { hbs as hbsThree } from 'ember-cli-htmlbars';
+// TODO: fix this to import a named export
+import hbsThree from 'ember-cli-htmlbars';
 
 module('tests/integration/components/test-inline-precompile', function(hooks) {
   setupRenderingTest(hooks);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,6 +1359,11 @@ babel-plugin-htmlbars-inline-precompile@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
   integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
+babel-plugin-htmlbars-inline-precompile@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-2.0.0.tgz#e08e0107468637f93625d159d3670dc19cf55e4f"
+  integrity sha512-08vtZNHseQ+uxN5DxK0ca1Qs1MWqzieuWF+pYkEzFohF+WxVNLiM1FN6ss5YP3BrigE68sI/yFrbJlO0bSb1XA==
+
 babel-plugin-module-resolver@^3.1.1, babel-plugin-module-resolver@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz#ddfa5e301e3b9aa12d852a9979f18b37881ff5a7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@ babel-plugin-htmlbars-inline-precompile@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
   integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
-babel-plugin-htmlbars-inline-precompile@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-2.0.0.tgz#e08e0107468637f93625d159d3670dc19cf55e4f"
-  integrity sha512-08vtZNHseQ+uxN5DxK0ca1Qs1MWqzieuWF+pYkEzFohF+WxVNLiM1FN6ss5YP3BrigE68sI/yFrbJlO0bSb1XA==
+babel-plugin-htmlbars-inline-precompile@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-2.1.0.tgz#92b0b23efc462c8df4d54c04a591b5d4111fd9c2"
+  integrity sha512-yoaNhhSO1bM5qgzwmK5y8EteCq6rOsrTjbgVFQoZcVuADAlDPYNcvin4120BR9UPG2qWD3mYwYPfY39kWq3WGA==
 
 babel-plugin-module-resolver@^3.1.1, babel-plugin-module-resolver@^3.2.0:
   version "3.2.0"
@@ -5500,12 +5500,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
* Bring initial implementation over from ember-cli-htmlbars-inline-precompile.
* Refactor to avoid duplication, streamline both .hbs transpilation and inline precompilation
* Add CI run to ensure there is no conflict with ember-cli-htmlbars-inline-precompile
* Add smoke tests ensuring that importing from all three known paths works

Allows consumers to use inline precompilation _without_ having
`ember-cli-htmlbars-inline-precompile` as a dependency. Example usage:

```js
import { hbs } from 'ember-cli-htmlbars';

export default Ember.Component.extend({
  layout: hbs`wheeeee`,
});
```

Implements https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/298