### PR TITLE
Do nothing in ColocatedTemplateProcessor if input tree is empty.

### DIFF
--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -33,6 +33,11 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
   build() {
     let files = walkSync(this.inputPaths[0], { directories: false });
 
+    if (files.length === 0) {
+      // nothing to do, bail
+      return;
+    }
+
     let root = detectRootName(files);
 
     let filesToCopy = [];

--- a/node-tests/colocated-plugin-test.js
+++ b/node-tests/colocated-plugin-test.js
@@ -227,6 +227,21 @@ describe('ColocatedTemplateCompiler', function() {
     assert.deepStrictEqual(output.read(), input.read());
   });
 
+  it('it works if there are no input files', async function() {
+    input.write({});
+
+    let tree = new ColocatedTemplateCompiler(input.path(), {
+      precompile(template) {
+        return JSON.stringify({ template });
+      },
+    });
+
+    output = createBuilder(tree);
+    await output.build();
+
+    assert.deepStrictEqual(output.read(), {});
+  });
+
   it('it works if input is manually using setComponentTemplate - no colocated template exists', async function() {
     input.write({
       'app-name-here': {


### PR DESCRIPTION
This cropped up during ember-cli's DELAYED_TRANSPILATION experiment
tests.