### PR TITLE
Avoid conflicts with ember-cli-htmlbars-inline-precompile

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -115,7 +115,7 @@ module.exports = function() {
           name: 'with-ember-cli-htmlbars-inline-precompile',
           npm: {
             devDependencies: {
-              'ember-cli-htmlbars-inline-precompile': '^2.1.0',
+              'ember-cli-htmlbars-inline-precompile': '^3.0.0',
             },
           },
         },

--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -86,6 +86,43 @@ dBabelVersion: ${hasValidBabelVersion};`
     if (type === 'parent') {
       this.parentRegistry = registry;
     }
+
+    let legacyInlinePrecompileAddon = this.parent.addons.find(
+      a => a.name === 'ember-cli-htmlbars-inline-precompile'
+    );
+    if (legacyInlinePrecompileAddon !== undefined) {
+      let heirarchy = ['ember-cli-htmlbars-inline-precompile'];
+      let pointer = this;
+      while (pointer.parent) {
+        heirarchy.push(pointer.pkg.name);
+        pointer = pointer.parent;
+      }
+
+      this.ui.writeDeprecateLine(
+        `${heirarchy
+          .reverse()
+          .join(
+            ' > '
+          )} is no longer needed with ember-cli-htmlbars versions 4.0.0 and higher, please remove it from \`${
+          this.parent.root
+        }/package.json\``
+      );
+
+      // overwrite the `included` method on the
+      // ember-cli-htmlbars-inline-precompile instance this prevents issues
+      // when using ember-cli-htmlbars-inline-precompile < 3.0.1 (where both
+      // this addon and ember-cli-htmlbars-inline-precompile use the same
+      // babel-plugin-htmlbars-inline-precompile version and get confused about
+      // whether or not it registers its replacements)
+      //
+      // this only mutates the local addon _instance_ (not **all** instances of
+      // the addon) because we _know_ that this instance of ember-cli-htmlbars
+      // will take care of the precompilation of:
+      //
+      // import hbs from 'htmlbars-inline-precompile';
+      // import hbs from 'ember-cli-htmlbars-inline-precompile';
+      legacyInlinePrecompileAddon.included = function() {};
+    }
   },
 
   included() {
@@ -104,15 +141,9 @@ dBabelVersion: ${hasValidBabelVersion};`
 
       let modules = {
         'ember-cli-htmlbars': 'hbs',
+        'ember-cli-htmlbars-inline-precompile': 'default',
+        'htmlbars-inline-precompile': 'default',
       };
-
-      // TODO: add deprecation to migrate import paths to use
-      // ember-cli-htmlbars instead of htmlbars-inline-precompile or
-      // ember-cli-htmlbars-inline-precompile
-      if (!this.parent.addons.find(a => a.name === 'ember-cli-htmlbars-inline-precompile')) {
-        modules['ember-cli-htmlbars-inline-precompile'] = 'default';
-        modules['htmlbars-inline-precompile'] = 'default';
-      }
 
       if (pluginInfo.canParallelize) {
         logger.debug('using parallel API with for babel inline precompilation plugin');
@@ -164,7 +195,7 @@ dBabelVersion: ${hasValidBabelVersion};`
   },
 
   /**
-   * This function checks if 'ember-cli-htmlbars-inline-precompile' is already present in babelPlugins.
+   * This function checks if 'babel-plugin-htmlbars-inline-precompile' is already present in babelPlugins.
    * The plugin object will be different for non parallel API and parallel API.
    * For parallel api, check the `baseDir` of a plugin to see if it has current dirname
    * For non parallel api, check the 'modules' to see if it contains the babel plugin
@@ -173,14 +204,24 @@ dBabelVersion: ${hasValidBabelVersion};`
   _isInlinePrecompileBabelPluginRegistered(plugins) {
     return plugins.some(plugin => {
       if (Array.isArray(plugin)) {
-        return plugin[0] === require.resolve('babel-plugin-htmlbars-inline-precompile');
+        let [pluginPathOrInstance, options] = plugin;
+
+        return (
+          pluginPathOrInstance === require.resolve('babel-plugin-htmlbars-inline-precompile') &&
+          typeof options.modules === 'object' &&
+          options.modules['ember-cli-htmlbars'] === 'hbs'
+        );
       } else if (
         plugin !== null &&
         typeof plugin === 'object' &&
         plugin._parallelBabel !== undefined
       ) {
         return (
-          plugin._parallelBabel.requireFile === path.resolve(__dirname, 'lib/require-from-worker')
+          plugin._parallelBabel.requireFile ===
+            path.resolve(__dirname, 'lib/require-from-worker') &&
+          typeof plugin._parallelBabel.params === 'object' &&
+          typeof plugin._parallelBabel.params.modules === 'object' &&
+          plugin._parallelBabel.params.modules['ember-cli-htmlbars'] === 'hbs'
         );
       } else {
         return false;


### PR DESCRIPTION
Both ember-cli-htmlbars-inline-precompile and ember-cli-htmlbars used the same _exact_ check to determine if `babel-plugin-htmlbars-inline-precompile` was registered. When the build was parallelizable we would properly detect that the babel-plugin-htmlbars-inline-precompile was or was not the one added by each respective addon (because the addon's own `__dirname` is included in the check) **but** when the build was not parallelizable the babel plugins array contains a standard Babel plugins array. In that case, both addons were _only_ checking if the plugin _path_ matched (via `require.resolve`) which was completely insufficient.

This issue resulted in `ember-cli-htmlbars-inline-precompile` _thinking_ that it was already registered _when_ the build was not parallelizable, which would subsequently make it not register its own instance of the plugin (to support import paths other than `ember-cli-htmlbars`).

The fix here is:

1. This forces any instances of ember-cli-htmlbars-inline-precompile addon to be completely inert if it is part of the same parent addon or app as ember-cli-htmlbars itself.  
2. Emit a deprecation notice when we identify that `ember-cli-htmlbars-inline-precompile` should be removed.
3. Updating the `_isInlinePrecompileBabelPluginRegistered` method to properly check if the plugin ember-cli-htmlbars is registering is already registered (with our configuration).

Fixes #312
Fixes #297
Closes #319
Fixes https://github.com/ember-cli/ember-cli/issues/8868