### PR TITLE
Ensure all debug logging is emitted with `DEBUG=ember-cli-htmlbars:*`

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const utils = require('./utils');
-const logger = require('heimdalljs-logger')('ember-cli-htmlbars');
+const logger = require('heimdalljs-logger')('ember-cli-htmlbars:addon');
 const hasEdition = require('@ember/edition-utils').has;
 
 let registryInvocationCounter = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const hashForDep = require('hash-for-dep');
 const debugGenerator = require('heimdalljs-logger');
-const logger = debugGenerator('ember-cli-htmlbars');
+const logger = debugGenerator('ember-cli-htmlbars:utils');
 const addDependencyTracker = require('./addDependencyTracker');
 
 function buildOptions(projectConfig, templateCompilerPath, pluginInfo) {


### PR DESCRIPTION
`heimdalljs-logger` does not print out log messages for `ember-cli-htmlbars` when `DEBUG=ember-cli-htmlbars:*` is used. This made getting access to these debug statements _slightly_ harder for folks.