### PR TITLE
Reproduce inline precompilation failures when using ember-cli-htmlbars-inline-precompile

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -115,7 +115,7 @@ module.exports = function() {
           name: 'with-ember-cli-htmlbars-inline-precompile',
           npm: {
             devDependencies: {
-              'ember-cli-htmlbars-inline-precompile': '^2.1.0',
+              'ember-cli-htmlbars-inline-precompile': '^3.0.0',
             },
           },
         },


### PR DESCRIPTION
We **specifically** had tests for the scenario that ultimately was reported as failing. The description in #317 explains the scenario better, but the failure scenario was only exposed IFF the same version of babel-plugin-htmlbars-inline-precompile was used (because both ember-cli-htmlbars-inline-precompile and ember-cli-htmlbars were comparing `require.resolve('babel-plugin-htmlbars-inline-precompile')` to determine if they should append the plugin again, so if they didn't use the same version #312 wasn't possible).

This updates the ember-try scenario to use ember-cli-htmlbars-inline-precompile@3.0.0, in order to replicate the error.