### PR TITLE
Ensure deprecation message shows correct heirarchy.

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -91,8 +91,8 @@ dBabelVersion: ${hasValidBabelVersion};`
       a => a.name === 'ember-cli-htmlbars-inline-precompile'
     );
     if (legacyInlinePrecompileAddon !== undefined) {
-      let heirarchy = ['ember-cli-htmlbars-inline-precompile'];
-      let pointer = this;
+      let heirarchy = [];
+      let pointer = legacyInlinePrecompileAddon;
       while (pointer.parent) {
         heirarchy.push(pointer.pkg.name);
         pointer = pointer.parent;


### PR DESCRIPTION
Previously it would show `ember-cli-htmlbars-inline-precompile` twice (once from the seeded array value, and again from the iteration).

This fixes that error.