### PR TITLE
More fixes for proper babel plugin deduplication.

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -139,37 +139,15 @@ dBabelVersion: ${hasValidBabelVersion};`
       let pluginInfo = this.astPlugins();
       let templateCompilerPath = this.templateCompilerPath();
 
-      let modules = {
-        'ember-cli-htmlbars': 'hbs',
-        'ember-cli-htmlbars-inline-precompile': 'default',
-        'htmlbars-inline-precompile': 'default',
-      };
-
       if (pluginInfo.canParallelize) {
         logger.debug('using parallel API with for babel inline precompilation plugin');
 
-        let parallelBabelInfo = {
-          requireFile: path.join(__dirname, 'require-from-worker'),
-          buildUsing: 'build',
-          params: {
-            templateCompilerPath,
-            parallelConfigs: pluginInfo.parallelConfigs,
-            modules,
-          },
-        };
-
-        // parallelBabelInfo will not be used in the cache unless it is explicitly included
-        let cacheKey = utils.makeCacheKey(
-          templateCompilerPath,
+        let htmlbarsInlinePrecompilePlugin = utils.buildParalleizedBabelPlugin(
           pluginInfo,
-          JSON.stringify(parallelBabelInfo)
+          templateCompilerPath
         );
 
-        babelPlugins.push({
-          _parallelBabel: parallelBabelInfo,
-          baseDir: () => __dirname,
-          cacheKey: () => cacheKey,
-        });
+        babelPlugins.push(htmlbarsInlinePrecompilePlugin);
       } else {
         logger.debug('NOT using parallel API with for babel inline precompilation plugin');
         logger.debug('Prevented by these plugins: ' + pluginInfo.unparallelizableWrappers);
@@ -177,7 +155,6 @@ dBabelVersion: ${hasValidBabelVersion};`
         let htmlBarsPlugin = utils.setup(pluginInfo, {
           projectConfig: this.projectConfig(),
           templateCompilerPath,
-          modules,
         });
 
         babelPlugins.push(htmlBarsPlugin);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,12 @@ const debugGenerator = require('heimdalljs-logger');
 const logger = debugGenerator('ember-cli-htmlbars:utils');
 const addDependencyTracker = require('./addDependencyTracker');
 
+const INLINE_PRECOMPILE_MODULES = Object.freeze({
+  'ember-cli-htmlbars': 'hbs',
+  'ember-cli-htmlbars-inline-precompile': 'default',
+  'htmlbars-inline-precompile': 'default',
+});
+
 function isInlinePrecompileBabelPluginRegistered(plugins) {
   return plugins.some(plugin => {
     if (Array.isArray(plugin)) {
@@ -38,6 +44,27 @@ function isColocatedBabelPluginRegistered(plugins) {
   return plugins.some(
     plugin => typeof plugin === 'string' && plugin === require.resolve('./colocated-babel-plugin')
   );
+}
+
+function buildParalleizedBabelPlugin(pluginInfo, templateCompilerPath) {
+  let parallelBabelInfo = {
+    requireFile: require.resolve('./require-from-worker'),
+    buildUsing: 'build',
+    params: {
+      templateCompilerPath,
+      parallelConfigs: pluginInfo.parallelConfigs,
+      modules: INLINE_PRECOMPILE_MODULES,
+    },
+  };
+
+  // parallelBabelInfo will not be used in the cache unless it is explicitly included
+  let cacheKey = makeCacheKey(templateCompilerPath, pluginInfo, JSON.stringify(parallelBabelInfo));
+
+  return {
+    _parallelBabel: parallelBabelInfo,
+    baseDir: () => __dirname,
+    cacheKey: () => cacheKey,
+  };
 }
 
 function buildOptions(projectConfig, templateCompilerPath, pluginInfo) {
@@ -171,7 +198,7 @@ function setup(pluginInfo, options) {
 
   let plugin = [
     require.resolve('babel-plugin-htmlbars-inline-precompile'),
-    { precompile, modules: options.modules },
+    { precompile, modules: INLINE_PRECOMPILE_MODULES },
     'ember-cli-htmlbars:inline-precompile',
   ];
 
@@ -256,4 +283,5 @@ module.exports = {
   setupPlugins,
   isColocatedBabelPluginRegistered,
   isInlinePrecompileBabelPluginRegistered,
+  buildParalleizedBabelPlugin,
 };

--- a/node-tests/utils_test.js
+++ b/node-tests/utils_test.js
@@ -128,19 +128,12 @@ describe('utils', function() {
         'ember-cli-htmlbars:inline-precompile',
       ];
 
-      parallelizablePlugin = {
-        baseDir: () => __dirname,
-        cacheKey: () => `${Date.now()}`,
-        _parallelBabel: {
-          requireFile: require.resolve('../lib/require-from-worker'),
-          buildUsing: 'build',
-          params: {
-            templateCompilerPath: null,
-            parallelConfigs: [],
-            modules,
-          },
-        },
-      };
+      let pluginInfo = { parallelConfigs: [], cacheKeys: [] };
+      parallelizablePlugin = utils.buildParalleizedBabelPlugin(
+        pluginInfo,
+        require.resolve('ember-source/dist/ember-template-compiler')
+      );
+
       [
         require.resolve('babel-plugin-htmlbars-inline-precompile'),
         { precompile: null, modules },


### PR DESCRIPTION
Ensure that the actual output used by the `included` hook when parallelizable returns `true` for `isInlinePrecompileBabelPluginRegistered`. Previously, we had a mismatch between `path.join(__dirname, 'require-from-worker')` and `require.resolve('./require-from-worker')` because `require.resolve`
includes the extension.

Closes https://github.com/ember-cli/ember-cli-htmlbars/issues/297 (again)