### PR TITLE
Enable colocated component classes to be TypeScript

### DIFF
--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -68,13 +68,23 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
         return;
       }
 
-      // TODO: deal with alternate extensions (e.g. ts)
-      let possibleJSPath = path.join(filePathParts.dir, filePathParts.name + '.js');
-      let hasJSFile = fs.existsSync(path.join(this.inputPaths[0], possibleJSPath));
-
       if (filePathParts.name === 'template') {
         filesToCopy.push(filePath);
         return;
+      }
+
+      let hasBackingClass = false;
+      let backingClassPath = path.join(filePathParts.dir, filePathParts.name);
+
+      if (fs.existsSync(path.join(this.inputPaths[0], backingClassPath + '.js'))) {
+        backingClassPath += '.js';
+        hasBackingClass = true;
+      } else if (fs.existsSync(path.join(this.inputPaths[0], backingClassPath + '.ts'))) {
+        backingClassPath += '.ts';
+        hasBackingClass = true;
+      } else {
+        backingClassPath += '.js';
+        hasBackingClass = false;
       }
 
       let templateContents = fs.readFileSync(inputPath, { encoding: 'utf8' });
@@ -92,12 +102,14 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
       )})`;
       let prefix = `import { hbs } from 'ember-cli-htmlbars';\nconst __COLOCATED_TEMPLATE__ = ${hbsInvocation};\n`;
 
-      logger.debug(`processing colocated template: ${filePath} (template-only: ${hasJSFile})`);
+      logger.debug(
+        `processing colocated template: ${filePath} (template-only: ${hasBackingClass})`
+      );
 
-      if (hasJSFile) {
+      if (hasBackingClass) {
         // add the template, call setComponentTemplate
 
-        jsContents = fs.readFileSync(path.join(this.inputPaths[0], possibleJSPath), {
+        jsContents = fs.readFileSync(path.join(this.inputPaths[0], backingClassPath), {
           encoding: 'utf8',
         });
 
@@ -114,7 +126,7 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
 
       jsContents = prefix + jsContents;
 
-      let outputPath = path.join(this.outputPath, possibleJSPath);
+      let outputPath = path.join(this.outputPath, backingClassPath);
 
       // TODO: don't speculatively mkdirSync (likely do in a try/catch with ENOENT)
       mkdirp.sync(path.dirname(outputPath));


### PR DESCRIPTION
Prior to this, we only looked for `*.js` files as the "backing class" and would actually create a `.js` file right next to the existing `.ts` file. This leads to a whole host of bugs for TypeScript users. :(

This updates the logic to look for `.js` file first then fall back to `.ts` files.

Address part of https://github.com/ember-cli/ember-cli-htmlbars/issues/308