### PR TITLE
Add additional tests for Colocated Components

### DIFF
--- a/tests/colocation/app/components/baz/index.hbs
+++ b/tests/colocation/app/components/baz/index.hbs
@@ -1,0 +1,1 @@
+Module: {{module-name-inliner}}

--- a/tests/colocation/app/components/foo/bar.hbs
+++ b/tests/colocation/app/components/foo/bar.hbs
@@ -1,0 +1,1 @@
+Module: {{module-name-inliner}}

--- a/tests/colocation/app/components/foo/baz/index.hbs
+++ b/tests/colocation/app/components/foo/baz/index.hbs
@@ -1,0 +1,1 @@
+Module: {{module-name-inliner}}

--- a/tests/integration/components/colocation-test.js
+++ b/tests/integration/components/colocation-test.js
@@ -17,4 +17,22 @@ module('tests/integration/components/test-inline-precompile', function(hooks) {
 
     assert.equal(this.element.textContent.trim(), 'Module: dummy/components/foo.hbs');
   });
+
+  test('registered ast plugins run against nested colocated templates (template-only)', async function(assert) {
+    await render(hbs`<Foo::Bar />`);
+
+    assert.equal(this.element.textContent.trim(), 'Module: dummy/components/foo/bar.hbs');
+  });
+
+  test('registered ast plugins run against colocated template index files (template-only)', async function(assert) {
+    await render(hbs`<Baz />`);
+
+    assert.equal(this.element.textContent.trim(), 'Module: dummy/components/baz/index.hbs');
+  });
+
+  test('registered ast plugins run against nested colocated template index files (template-only)', async function(assert) {
+    await render(hbs`<Foo::Baz />`);
+
+    assert.equal(this.element.textContent.trim(), 'Module: dummy/components/foo/baz/index.hbs');
+  });
 });


### PR DESCRIPTION
After reading https://github.com/ember-cli/ember-cli-htmlbars/issues/330 I thought that the test coverage for colocated templates could be improved.

I see that issue might not actually be a bug, and I'm not sure if my tests prove that or not since that issue talks about re-exporting components in addons, but I figured a few additional test cases couldn't hurt,