### PR TITLE
Support `as default` exports with template colocation

### DIFF
--- a/lib/colocated-babel-plugin.js
+++ b/lib/colocated-babel-plugin.js
@@ -3,6 +3,14 @@
 module.exports = function(babel) {
   let t = babel.types;
 
+  function makeSetComponentTemplateMemberExpression() {
+    return t.memberExpression(t.identifier('Ember'), t.identifier('_setComponentTemplate'));
+  }
+
+  function makeColocatedTemplateIdentifier() {
+    return t.identifier('__COLOCATED_TEMPLATE__');
+  }
+
   return {
     name: 'ember-cli-htmlbars-colocation-template',
 
@@ -19,11 +27,8 @@ module.exports = function(babel) {
         }
 
         let defaultExportDeclaration = path.node.declaration;
-        let setComponentTemplateMemberExpression = t.memberExpression(
-          t.identifier('Ember'),
-          t.identifier('_setComponentTemplate')
-        );
-        let colocatedTemplateIdentifier = t.identifier('__COLOCATED_TEMPLATE__');
+        let setComponentTemplateMemberExpression = makeSetComponentTemplateMemberExpression();
+        let colocatedTemplateIdentifier = makeColocatedTemplateIdentifier();
 
         if (defaultExportDeclaration.type === 'ClassDeclaration') {
           // when the default export is a ClassDeclaration with an `id`,
@@ -54,6 +59,24 @@ module.exports = function(babel) {
             colocatedTemplateIdentifier,
             defaultExportDeclaration,
           ]);
+        }
+      },
+
+      ExportNamedDeclaration(path, state) {
+        if (!state.colocatedTemplateFound) {
+          return;
+        }
+
+        let defaultSpecifier = path.node.specifiers.find(spec => spec.exported.name === 'default');
+        if (defaultSpecifier) {
+          path.parent.body.push(
+            t.expressionStatement(
+              t.callExpression(makeSetComponentTemplateMemberExpression(), [
+                makeColocatedTemplateIdentifier(),
+                defaultSpecifier.local,
+              ])
+            )
+          );
         }
       },
     },

--- a/node-tests/babel-plugin-test.js
+++ b/node-tests/babel-plugin-test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const assert = require('assert');
+const babel = require('@babel/core');
+const { stripIndent } = require('common-tags');
+const ColocatedBabelPlugin = require('../lib/colocated-babel-plugin');
+
+describe('ColocatedBabelPlugin', function() {
+  this.slow(500);
+
+  it('sets the template for non-class default exports', function() {
+    let { code } = babel.transformSync(
+      stripIndent`
+        import MyComponent from 'other-module';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        export default MyComponent;
+      `,
+      { plugins: [ColocatedBabelPlugin] }
+    );
+
+    assert.strictEqual(
+      code,
+      stripIndent`
+        import MyComponent from 'other-module';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        export default Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, MyComponent);
+      `
+    );
+  });
+
+  it('sets the template for named class default exports', function() {
+    let { code } = babel.transformSync(
+      stripIndent`
+        import Component from 'somewhere';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        export default class MyComponent extends Component {}
+      `,
+      { plugins: [ColocatedBabelPlugin] }
+    );
+
+    assert.strictEqual(
+      code,
+      stripIndent`
+        import Component from 'somewhere';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        export default class MyComponent extends Component {}
+
+        Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, MyComponent);
+      `
+    );
+  });
+
+  it('sets the template for anonymous class default exports', function() {
+    let { code } = babel.transformSync(
+      stripIndent`
+        import Component from 'somewhere';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        export default class extends Component {}
+      `,
+      { plugins: [ColocatedBabelPlugin] }
+    );
+
+    assert.strictEqual(
+      code,
+      stripIndent`
+        import Component from 'somewhere';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        export default Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, class extends Component {});
+      `
+    );
+  });
+
+  it('sets the template for identifier `as default` exports', function() {
+    let { code } = babel.transformSync(
+      stripIndent`
+        import Component from 'somewhere';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        const MyComponent = class extends Component {};
+        export { MyComponent as default };
+      `,
+      { plugins: [ColocatedBabelPlugin] }
+    );
+
+    assert.strictEqual(
+      code,
+      stripIndent`
+        import Component from 'somewhere';
+        const __COLOCATED_TEMPLATE__ = 'ok';
+        const MyComponent = class extends Component {};
+        export { MyComponent as default };
+
+        Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, MyComponent);
+      `
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "walk-sync": "^2.0.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.6.4",
     "@ember/optional-features": "^1.0.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "broccoli-merge-trees": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,12 +29,42 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
+  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.4"
+    "@babel/helpers" "^7.6.2"
+    "@babel/parser" "^7.6.4"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.6.2":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.2.tgz#dac8a3c2df118334c2a29ff3446da1636a8f8c03"
   integrity sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==
   dependencies:
     "@babel/types" "^7.6.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
+  dependencies:
+    "@babel/types" "^7.6.3"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -228,6 +258,11 @@
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.2.tgz#205e9c95e16ba3b8b96090677a67c9d6075b70a1"
   integrity sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==
+
+"@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
+  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -711,10 +746,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
+  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.3"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -6773,9 +6832,8 @@ mocha@^6.2.1:
     yargs-unparser "1.6.0"
 
 "module-name-inliner@link:./tests/dummy/lib/module-name-inliner":
-  version "0.1.0"
-  dependencies:
-    ember-cli-version-checker "*"
+  version "0.0.0"
+  uid ""
 
 morgan@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
We discovered in https://github.com/typed-ember/ember-cli-typescript/issues/906 that `@babel/plugin-transform-typescript` can transform default export statements into named `export { foo as default }` statements under certain conditions, which isn't currently detected by the colocation babel plugin.

This PR updates the babel plugin to account for this case, as well as adding some direct testing with `@babel/core`. If there's another testing approach that's preferable, I'm happy to update.