### PR TITLE
Add `ember-octane` test suite run to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
          - ember-lts-3.8
          - ember-lts-3.12
          - ember-release
+         - ember-octane
          - ember-beta
          - ember-canary
          - ember-default


### PR DESCRIPTION
We have a number of tests setup that only run when `setEdition('octane')` has ran, but unfortunately I forgot to add it to CI :sob: