### PR TITLE
Remove manual `yarn` installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: install yarn
-      run: npm install -g yarn
     - name: install dependencies
       run: yarn install
     - name: lint:js
@@ -42,8 +40,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: install yarn
-      run: npm install -g yarn
     - name: install dependencies
       run: yarn install
     - name: node tests
@@ -62,8 +58,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: install yarn
-      run: npm install -g yarn
     - name: install dependencies
       run: yarn install --ignore-lockfile
     - name: node tests
@@ -100,8 +94,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: install yarn
-      run: npm install -g yarn
     - name: install dependencies
       run: yarn install
     - name: test

--- a/testem.js
+++ b/testem.js
@@ -3,6 +3,7 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
An update to the GH actions CI environment made `npm i -g yarn` error (because `yarn` is already installed and cannot be overwritten by the user process owner). This removes the manual installation as it is not needed any longer.