### PR TITLE
Remove `setEdition` requirement for colocation.

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const utils = require('./utils');
-const hasEdition = require('@ember/edition-utils').has;
 
 let registryInvocationCounter = 0;
 
@@ -30,6 +29,9 @@ module.exports = {
     let hasBabel = babel !== undefined;
     let babelVersion = hasBabel && babel.pkg.version;
 
+    let ember = this.project.addons.find(a => a.name === 'ember-source');
+    let emberVersion = ember !== undefined && ember.pkg.version;
+
     // using this.project.emberCLIVersion() allows us to avoid issues when `npm
     // link` is used; if this addon were linked and we did something like
     // `require('ember-cli/package').version` we would get our own ember-cli
@@ -38,13 +40,16 @@ module.exports = {
 
     let hasValidBabelVersion = hasBabel && semver.gte(babelVersion, '7.11.0');
     let hasValidEmberCLIVersion = semver.gte(emberCLIVersion, '3.12.0-beta.2');
-    let hasOctane = hasEdition('octane');
+
+    // once a polyfill is written, we will need to update this logic to check
+    // for _either_ `ember-source@3.13` or the polyfill
+    let hasValidEmberVersion = semver.gte(emberVersion, '3.13.0');
 
     this._cachedShouldColocateTemplates =
-      hasOctane && hasValidBabelVersion && hasValidEmberCLIVersion;
+      hasValidEmberVersion && hasValidBabelVersion && hasValidEmberCLIVersion;
 
     this.logger.info(
-      `Colocation processing: ${this._cachedShouldColocateTemplates} (hasOctane: ${hasOctane}; hasValidEmberCLIVersion: ${hasValidEmberCLIVersion}; hasValidBabelVersion: ${hasValidBabelVersion};`
+      `Colocation processing: ${this._cachedShouldColocateTemplates} (hasValidEmberVersion: ${hasValidEmberVersion} hasValidEmberCLIVersion: ${hasValidEmberCLIVersion}; hasValidBabelVersion: ${hasValidBabelVersion};`
     );
 
     return this._cachedShouldColocateTemplates;


### PR DESCRIPTION
Changes the `_cachedShouldColocateTemplates` logic to require the following:

* `ember-cli-babel` >= 7.11.0
* `ember-cli` >= 3.12.0-beta.2
* `ember-source` >= 3.13.0

In the future, when we have a `setComponentTemplate` and `templateOnly` polyfill we can update the `ember-source` requirement to also check for the polyfill.