### PR TITLE
Ensure inline precompilation does not error when a template contains `*/`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6873,9 +6873,8 @@ mocha@^6.2.2:
     yargs-unparser "1.6.0"
 
 "module-name-inliner@link:./tests/dummy/lib/module-name-inliner":
-  version "0.1.0"
-  dependencies:
-    ember-cli-version-checker "*"
+  version "0.0.0"
+  uid ""
 
 morgan@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Update babel-plugin-htmlbars-inline-precompile to 3.0.1 to fix an issue with inline templates containing `*/`.

Prior to this a template like:

```js
hbs`some content */`
```

Would emit invalid JS:

```js
Ember.HTMLBars.template(
  /*
    some content */
  */
  {
    // some stuff emitted by actual compilation
  }
)
```

The comment showing the original template was added as a developer aide (makes looking at files with many inline templates such as tests much easier), but without escaping `*/` we risk the template content itself breaking the JS parsing within the file.

This commit ensures that `*/` is escaped to `*\/` which avoids the issue.

Fixes #391