### PR TITLE
Only check semver range if ember-source is present

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -30,7 +30,8 @@ module.exports = {
     let babelVersion = hasBabel && babel.pkg.version;
 
     let ember = this.project.addons.find(a => a.name === 'ember-source');
-    let emberVersion = ember !== undefined && ember.pkg.version;
+    let hasEmberSource = ember !== undefined;
+    let emberVersion = hasEmberSource && ember.pkg.version;
 
     // using this.project.emberCLIVersion() allows us to avoid issues when `npm
     // link` is used; if this addon were linked and we did something like
@@ -43,7 +44,7 @@ module.exports = {
 
     // once a polyfill is written, we will need to update this logic to check
     // for _either_ `ember-source@3.13` or the polyfill
-    let hasValidEmberVersion = semver.gte(emberVersion, '3.13.0');
+    let hasValidEmberVersion = hasEmberSource && semver.gte(emberVersion, '3.13.0');
 
     this._cachedShouldColocateTemplates =
       hasValidEmberVersion && hasValidBabelVersion && hasValidEmberCLIVersion;


### PR DESCRIPTION
Prior to this patch the value `false` would be passed to `semver.gte(` causing an exception of `Invalid Version: false`. This ensures the range validity of the version is only checked if one is present.

Specifically bower versions of Ember have an `emberVersion` of `false` here. However none of those versions of Ember support co-location.

Fixes #422