### PR TITLE
Revert "Bump semver from 6.3.0 to 7.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "hash-for-dep": "^1.5.1",
     "heimdalljs-logger": "^0.1.10",
     "json-stable-stringify": "^1.0.1",
-    "semver": "^7.0.0",
+    "semver": "^6.3.0",
     "strip-bom": "^4.0.0",
     "walk-sync": "^2.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8441,11 +8441,6 @@ semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
-  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
This reverts commit 1c62ef668b3db753c5ff480365da779ead250c74.

**_tldr;_** `semver@7.x` _arguably_ includes breaking changes in a minor release (from 7.0.0 to 7.1.0), and we cannot update to 7.x until ember-cli-htmlbars drops Node 8 support.

At the time the `semver@7.0.0` version bump (from 1c62ef66) landed the CHANGELOG.md for `semver@7.0.0` stated:

* Refactor module into separate files for better tree-shaking
* Drop support for very old node versions, use const/let, => functions, and classes.

The verbiage here is obviously imprecise, and when merging (and releasing) I misinterpretted "very old node versions" as being versions older than Node 4.0.0 (in other words, versions that didn't support the features stated immediately following). Unfortunately, semver changed their `engines` version _after_ 7.0.0 was released (included in the 7.1.0 release) to only allow Node 10 or higher (see [here](https://github.com/npm/node-semver/commit/d61f828e64260a0a097f26210f5500e91a621828)).  Unfortunately, due to the way `yarn` works by default, this change in `engines` is actually a breaking change for `yarn` users (unless they specify the `--ignore-engines` flag).