### PR TITLE
fix: Standardize the option name for dependency invalidation.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -267,7 +267,7 @@ function setupPlugins(wrappers) {
     parallelConfigs,
     canParallelize,
     unparallelizableWrappers,
-    hasDependencyInvalidation: !!dependencyInvalidation,
+    dependencyInvalidation: !!dependencyInvalidation,
   };
 }
 

--- a/node-tests/utils_test.js
+++ b/node-tests/utils_test.js
@@ -46,7 +46,7 @@ describe('utils', function() {
         parallelConfigs: [],
         canParallelize: true,
         unparallelizableWrappers: [],
-        hasDependencyInvalidation: false,
+        dependencyInvalidation: false,
       });
     });
 
@@ -76,7 +76,7 @@ describe('utils', function() {
         parallelConfigs: ['something', 'something else'],
         canParallelize: true,
         unparallelizableWrappers: [],
-        hasDependencyInvalidation: false,
+        dependencyInvalidation: false,
       });
     });
 
@@ -107,7 +107,7 @@ describe('utils', function() {
         parallelConfigs: ['something'],
         canParallelize: false,
         unparallelizableWrappers: ['second'],
-        hasDependencyInvalidation: false,
+        dependencyInvalidation: false,
       });
     });
   });


### PR DESCRIPTION
TL;DR Dependency invalidation wasn't getting enabled automatically when it should have been.

We were reading the value out of pluginInfo as dependencyInvalidation but putting the value into pluginInfo as hasDependencyInvalidation.

Since we use the option dependencyInvalidation elsewhere, I've standardized on that.