### PR TITLE
Remove usage of legacy `checker.forEmber` API.

### DIFF
--- a/tests/dummy/lib/module-name-inliner/index.js
+++ b/tests/dummy/lib/module-name-inliner/index.js
@@ -12,7 +12,7 @@ module.exports = {
   setupPreprocessorRegistry(type, registry) {
     // can only add the plugin with this style on newer Ember versions
     let checker = new VersionChecker(this.project);
-    if (checker.forEmber().gte('3.1.0')) {
+    if (checker.for('ember-source').gte('3.1.0')) {
       registry.add('htmlbars-ast-plugin', this.buildPlugin());
     }
 


### PR DESCRIPTION
This was removed in ember-cli-version-checker@5.0.0, and in some cases we end up with a node_modules graph with that at the top level. Unfortunately, we cannot update to v5.x yet because it also dropped Node 8 support.

This change is backwards compatible all the way to v1, and should unblock CI until we can drop Node 8 and update to ember-cli-version-checker@5.