### PR TITLE
Remove Bower support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ await render(hbs`
 
 There is a [codemod](https://github.com/ember-codemods/ember-cli-htmlbars-inline-precompile-codemod) available to automate this change.
 
+### Custom Template Compiler
+
+You can still provide a custom path to the template compiler (e.g. to test
+custom template compiler tweaks in an application) by:
+
+```js
+// ember-cli-build.js
+
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, {
+    'ember-cli-htmlbars': {
+      templateCompilerPath: `some_path/to/ember-template-compiler.js`,
+    }
+  });
+};
+```
+
 ### Handlebars 2.0 Support (Ember < 1.10)
 
 Handlebars 2.0 support has been removed. If you are using ember-cli-htmlbars with a 1.9.x project please continue

--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const path = require('path');
+const SilentError = require('silent-error');
 const utils = require('./utils');
 
 let registryInvocationCounter = 0;
@@ -191,20 +191,18 @@ module.exports = {
     let templateCompilerPath =
       config['ember-cli-htmlbars'] && config['ember-cli-htmlbars'].templateCompilerPath;
 
+    if (templateCompilerPath) {
+      return templateCompilerPath;
+    }
+
     let ember = this.project.findAddonByName('ember-source');
-    if (ember) {
-      return ember.absolutePaths.templateCompiler;
-    } else if (!templateCompilerPath) {
-      templateCompilerPath = this.project.bowerDirectory + '/ember/ember-template-compiler';
+    if (!ember) {
+      throw new SilentError(
+        `ember-cli-htmlbars: Cannot find the ember-source addon as part of the project, please ensure that 'ember-source' is in your projects dependencies or devDependencies`
+      );
     }
 
-    let absolutePath = path.resolve(this.project.root, templateCompilerPath);
-
-    if (path.extname(absolutePath) === '') {
-      absolutePath += '.js';
-    }
-
-    return absolutePath;
+    return ember.absolutePaths.templateCompiler;
   },
 
   htmlbarsOptions() {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "heimdalljs-logger": "^0.1.10",
     "json-stable-stringify": "^1.0.1",
     "semver": "^6.3.0",
+    "silent-error": "^1.1.1",
     "strip-bom": "^4.0.0",
     "walk-sync": "^2.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7072,9 +7072,8 @@ mocha@^7.1.1:
     yargs-unparser "1.6.0"
 
 "module-name-inliner@link:./tests/dummy/lib/module-name-inliner":
-  version "0.1.0"
-  dependencies:
-    ember-cli-version-checker "*"
+  version "0.0.0"
+  uid ""
 
 morgan@^1.9.1:
   version "1.9.1"
@@ -8399,6 +8398,13 @@ resolve@^1.1.3, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.0.tgz#6d14c6f9db9f8002071332b600039abf82053f64"
   integrity sha512-uviWSi5N67j3t3UKFxej1loCH0VZn5XuqdNxoLShPcYPw6cUZn74K1VRj+9myynRX03bxIBEkwlkob/ujLsJVw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.13.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
+  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
Retrieving `ember-template-compiler` from `bower_components` is only required when using Ember versions older than 2.12. Bower itself is essentially deprecated, this removes the fallback code to use `bower_components/ember/ember-template-compiler.js` and improves the error message when we can't actually find `ember-source`.

You can still provide a custom path to the template compiler (and therefore use Bower if you wish) by:

```js
// ember-cli-build.js

module.exports = function(defaults) {
  let app = new EmberApp(defaults, {
    'ember-cli-htmlbars': {
      templateCompilerPath: `some_path/to/ember-template-compiler.js`,
    }
  });
};
```