### PR TITLE
Use smaller cacheKey

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const hashForDep = require('hash-for-dep');
@@ -207,7 +208,10 @@ function setup(pluginInfo, options) {
 
 function makeCacheKey(templateCompilerPath, pluginInfo, extra) {
   let templateCompilerFullPath = require.resolve(templateCompilerPath);
-  let templateCompilerCacheKey = fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' });
+  let templateCompilerCacheKey = crypto
+    .createHash('md5')
+    .update(fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' }))
+    .digest('hex');
   let cacheItems = [templateCompilerCacheKey, extra].concat(pluginInfo.cacheKeys.sort());
   // extra may be undefined
   return cacheItems.filter(Boolean).join('|');


### PR DESCRIPTION
The whole file content string of template compiler is ~700kb, full path
should be enough for cacheKey