### PR TITLE
Fix specifying custom template compiler path.

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -187,9 +187,12 @@ module.exports = {
   },
 
   templateCompilerPath() {
-    let config = this.projectConfig();
+    let app = this._findHost();
     let templateCompilerPath =
-      config['ember-cli-htmlbars'] && config['ember-cli-htmlbars'].templateCompilerPath;
+      app &&
+      app.options &&
+      app.options['ember-cli-htmlbars'] &&
+      app.options['ember-cli-htmlbars'].templateCompilerPath;
 
     if (templateCompilerPath) {
       return templateCompilerPath;


### PR DESCRIPTION
The code that landed initially in 5.0.0 incorrectly used `config/environment.js` for the source of the value.