### PR TITLE
Ensure `EmberENV` is available to inline template compilation

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -156,6 +156,7 @@ module.exports = {
 
         let htmlbarsInlinePrecompilePlugin = utils.buildParalleizedBabelPlugin(
           pluginInfo,
+          this.projectConfig(),
           templateCompilerPath
         );
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,12 +47,13 @@ function isColocatedBabelPluginRegistered(plugins) {
   );
 }
 
-function buildParalleizedBabelPlugin(pluginInfo, templateCompilerPath) {
+function buildParalleizedBabelPlugin(pluginInfo, projectConfig, templateCompilerPath) {
   let parallelBabelInfo = {
     requireFile: require.resolve('./require-from-worker'),
     buildUsing: 'build',
     params: {
       templateCompilerPath,
+      projectConfig,
       parallelConfigs: pluginInfo.parallelConfigs,
       modules: INLINE_PRECOMPILE_MODULES,
     },

--- a/node-tests/utils_test.js
+++ b/node-tests/utils_test.js
@@ -131,6 +131,7 @@ describe('utils', function () {
       let pluginInfo = { parallelConfigs: [], cacheKeys: [] };
       parallelizablePlugin = utils.buildParalleizedBabelPlugin(
         pluginInfo,
+        {},
         require.resolve('ember-source/dist/ember-template-compiler')
       );
 


### PR DESCRIPTION
Prior to this, any settings in `EmberENV` were not available for inline
compilation (but they are for stand alone `.hbs` files).