### PR TITLE
Ensure custom templateCompilerPath is an absolute path.

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const SilentError = require('silent-error');
 const utils = require('./utils');
 
@@ -201,7 +202,7 @@ module.exports = {
       app.options['ember-cli-htmlbars'].templateCompilerPath;
 
     if (templateCompilerPath) {
-      return templateCompilerPath;
+      return path.resolve(this.project.root, templateCompilerPath);
     }
 
     let ember = this.project.findAddonByName('ember-source');


### PR DESCRIPTION
The examples that we show for using a custom template compiler path use a relative path, but that doesn't actually work when inline compilation runs and is parallelized (because the worker processes run from a different relative root inside `/tmp`).

This ensures that any specified overrides are converted to absolute paths.