### PR TITLE
Place colocated templates after the default export

### DIFF
--- a/lib/colocated-babel-plugin.js
+++ b/lib/colocated-babel-plugin.js
@@ -23,7 +23,21 @@ module.exports = function (babel) {
 
       ExportDefaultDeclaration(path, state) {
         if (state.colocatedTemplateFound !== true || state.setComponentTemplateInjected === true) {
-          return;
+          let colocatedFlagIndex = path.parent.body.findIndex( (node) => {
+
+            if(node.type === "VariableDeclaration")
+            {
+              if(node.declarations.findIndex( (declaration) => {
+  
+                if(declaration.id.name === '__COLOCATED_TEMPLATE__') return true;
+                return false;
+  
+              }) >= 0) return true;
+              return false;
+            }
+  
+          });
+          if (colocatedFlagIndex < 0) return;
         }
 
         state.setComponentTemplateInjected = true;

--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -155,13 +155,15 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
           jsContents = `${jsContents}\nthrow new Error(${JSON.stringify(message)});`;
           prefix = '';
         }
+        else if(hasTemplate) jsContents = jsContents + `\n${prefix}`;
+
       } else {
         // create JS file, use null component pattern
 
-        jsContents = `import templateOnly from '@ember/component/template-only';\n\nexport default templateOnly();\n`;
+        jsContents = prefix + `import templateOnly from '@ember/component/template-only';\n\nexport default templateOnly();\n`;
       }
 
-      jsContents = prefix + jsContents;
+      //jsContents = prefix + jsContents;
 
       let jsOutputPath = path.join(this.outputPath, backingClassPath);
 

--- a/node-tests/colocated-broccoli-plugin-test.js
+++ b/node-tests/colocated-broccoli-plugin-test.js
@@ -105,12 +105,11 @@ describe('ColocatedTemplateCompiler', function () {
         'router.js': '// stuff here',
         components: {
           'foo.js': stripIndent`
-            import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
             import Component from '@glimmer/component';
 
             export default class FooComponent extends Component {}
-          `,
+            import { hbs } from 'ember-cli-htmlbars';
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
         },
         templates: {
           'application.hbs': '{{outlet}}',
@@ -212,12 +211,11 @@ describe('ColocatedTemplateCompiler', function () {
       'app-name-here': {
         components: {
           'foo.ts': stripIndent`
-            import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
             import Component from '@glimmer/component';
 
             export default class FooComponent extends Component {}
-          `,
+            import { hbs } from 'ember-cli-htmlbars';
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
         },
         templates: {
           'application.hbs': '{{outlet}}',
@@ -255,11 +253,10 @@ describe('ColocatedTemplateCompiler', function () {
       'app-name-here': {
         components: {
           'foo.coffee': stripIndent`
-            import { hbs } from 'ember-cli-htmlbars'
-            __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}})
             import Component from '@ember/component'
             export default class extends Component
-          `,
+            import { hbs } from 'ember-cli-htmlbars'
+            __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}})` + '\n',
         },
         templates: {
           'application.hbs': '{{outlet}}',
@@ -344,12 +341,11 @@ describe('ColocatedTemplateCompiler', function () {
         'addon-name-here': {
           components: {
             'foo.js': stripIndent`
-            import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"@scope-name/addon-name-here/components/foo.hbs","parseOptions":{"srcName":"@scope-name/addon-name-here/components/foo.hbs"}});
             import Component from '@glimmer/component';
 
             export default class FooComponent extends Component {}
-          `,
+            import { hbs } from 'ember-cli-htmlbars';
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"@scope-name/addon-name-here/components/foo.hbs","parseOptions":{"srcName":"@scope-name/addon-name-here/components/foo.hbs"}});` + '\n',
           },
           templates: {
             'application.hbs': '{{outlet}}',
@@ -585,12 +581,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-              import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooComponent extends Component {}
-            `,
+              import { hbs } from 'ember-cli-htmlbars';
+              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',
@@ -670,12 +665,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-              import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooComponent extends Component {}
-            `,
+              import { hbs } from 'ember-cli-htmlbars';
+              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',
@@ -937,12 +931,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-                import { hbs } from 'ember-cli-htmlbars';
-                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                 import Component from '@glimmer/component';
 
                 export default class FooComponent extends Component {}
-              `,
+                import { hbs } from 'ember-cli-htmlbars';
+                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',
@@ -979,12 +972,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-              import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("whoops!", {"contents":"whoops!","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooComponent extends Component {}
-            `,
+              import { hbs } from 'ember-cli-htmlbars';
+              const __COLOCATED_TEMPLATE__ = hbs("whoops!", {"contents":"whoops!","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',
@@ -1025,12 +1017,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-                import { hbs } from 'ember-cli-htmlbars';
-                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                 import Component from '@glimmer/component';
 
                 export default class FooComponent extends Component {}
-              `,
+                import { hbs } from 'ember-cli-htmlbars';
+                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',
@@ -1065,12 +1056,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-              import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooBarComponent extends Component {}
-            `,
+              import { hbs } from 'ember-cli-htmlbars';
+              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',
@@ -1117,12 +1107,11 @@ describe('ColocatedTemplateCompiler', function () {
             'router.js': '// stuff here',
             components: {
               'foo.js': stripIndent`
-                import { hbs } from 'ember-cli-htmlbars';
-                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                 import Component from '@glimmer/component';
 
                 export default class FooComponent extends Component {}
-              `,
+                import { hbs } from 'ember-cli-htmlbars';
+                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});` + '\n',
             },
             templates: {
               'application.hbs': '{{outlet}}',

--- a/node-tests/colocated-test.js
+++ b/node-tests/colocated-test.js
@@ -131,6 +131,8 @@ describe('Colocation - Broccoli + Babel Integration', function () {
       'app-name-here': {
         components: {
           'foo.js': stripIndent`
+            import Component from '@glimmer/component';
+            export default class FooComponent extends Component {}
             import { hbs } from 'ember-cli-htmlbars';
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
@@ -140,9 +142,6 @@ describe('Colocation - Broccoli + Babel Integration', function () {
                 "srcName": "app-name-here/components/foo.hbs"
               }
             });
-
-            import Component from '@glimmer/component';
-            export default class FooComponent extends Component {}
 
             Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, FooComponent);
           `,
@@ -179,6 +178,8 @@ describe('Colocation - Broccoli + Babel Integration', function () {
       'app-name-here': {
         components: {
           'foo.js': stripIndent`
+            import Component from '@glimmer/component';
+            export default class FooComponent extends Component {}
             import { hbs } from 'ember-cli-htmlbars';
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
@@ -188,9 +189,6 @@ describe('Colocation - Broccoli + Babel Integration', function () {
                 "srcName": "app-name-here/components/foo.hbs"
               }
             });
-
-            import Component from '@glimmer/component';
-            export default class FooComponent extends Component {}
 
             Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, FooComponent);
           `,
@@ -274,6 +272,8 @@ describe('Colocation - Broccoli + Babel Integration', function () {
         'addon-name-here': {
           components: {
             'foo.js': stripIndent`
+            import Component from '@glimmer/component';
+            export default class FooComponent extends Component {}
             import { hbs } from 'ember-cli-htmlbars';
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
@@ -283,9 +283,6 @@ describe('Colocation - Broccoli + Babel Integration', function () {
                 "srcName": "@scope-name/addon-name-here/components/foo.hbs"
               }
             });
-
-            import Component from '@glimmer/component';
-            export default class FooComponent extends Component {}
 
             Ember._setComponentTemplate(__COLOCATED_TEMPLATE__, FooComponent);
           `,


### PR DESCRIPTION
I noticed that the source maps for component js files have a line number offset and so breakpoints and watches in VSCode doesn’t work properly. Only debugging from Chrome is possible.

After short investigation I found out that it is due to the template colocation feature. It prepends the template to the component class and so the resulting line numbers doesn't match the ones of the original js file.

I thought about appending the template to the component class instead of prepending it, in order to have the colocation feature not braking map files.

It seems working, the tests are updated and passing. I am already testing it on my local machine on production projects and I can easily switch back to the current version, so in the next days I will have detailed feedback. I decided to send a pull request in advance to have also your idea about this.