### PR TITLE
Pass moduleName to precompile inside meta.

### DIFF
--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -125,7 +125,9 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
         let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
         let hbsInvocationOptions = {
           contents: templateContents,
-          moduleName: relativeTemplatePath,
+          meta: {
+            moduleName: relativeTemplatePath,
+          },
           parseOptions: {
             srcName: relativeTemplatePath,
           },

--- a/lib/template-compiler-plugin.js
+++ b/lib/template-compiler-plugin.js
@@ -71,7 +71,9 @@ class TemplateCompiler extends Filter {
         'export default ' +
         utils.template(this.options.templateCompiler, stripBom(string), {
           contents: string,
-          moduleName: relativePath,
+          meta: {
+            moduleName: relativePath,
+          },
           parseOptions: {
             srcName: srcName,
           },

--- a/node-tests/colocated-broccoli-plugin-test.js
+++ b/node-tests/colocated-broccoli-plugin-test.js
@@ -47,7 +47,7 @@ describe('ColocatedTemplateCompiler', function () {
           'foo.js':
             stripIndent`
             import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
             import templateOnly from '@ember/component/template-only';
 
             export default templateOnly();` + '\n',
@@ -106,7 +106,7 @@ describe('ColocatedTemplateCompiler', function () {
         components: {
           'foo.js': stripIndent`
             import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
             import Component from '@glimmer/component';
 
             export default class FooComponent extends Component {}
@@ -213,7 +213,7 @@ describe('ColocatedTemplateCompiler', function () {
         components: {
           'foo.ts': stripIndent`
             import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
             import Component from '@glimmer/component';
 
             export default class FooComponent extends Component {}
@@ -256,7 +256,7 @@ describe('ColocatedTemplateCompiler', function () {
         components: {
           'foo.coffee': stripIndent`
             import { hbs } from 'ember-cli-htmlbars'
-            __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}})
+            __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}})
             import Component from '@ember/component'
             export default class extends Component
           `,
@@ -298,7 +298,7 @@ describe('ColocatedTemplateCompiler', function () {
             'foo.js':
               stripIndent`
             import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"@scope-name/addon-name-here/components/foo.hbs","parseOptions":{"srcName":"@scope-name/addon-name-here/components/foo.hbs"}});
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"@scope-name/addon-name-here/components/foo.hbs"},"parseOptions":{"srcName":"@scope-name/addon-name-here/components/foo.hbs"}});
             import templateOnly from '@ember/component/template-only';
 
             export default templateOnly();` + '\n',
@@ -345,7 +345,7 @@ describe('ColocatedTemplateCompiler', function () {
           components: {
             'foo.js': stripIndent`
             import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"@scope-name/addon-name-here/components/foo.hbs","parseOptions":{"srcName":"@scope-name/addon-name-here/components/foo.hbs"}});
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"@scope-name/addon-name-here/components/foo.hbs"},"parseOptions":{"srcName":"@scope-name/addon-name-here/components/foo.hbs"}});
             import Component from '@glimmer/component';
 
             export default class FooComponent extends Component {}
@@ -541,7 +541,7 @@ describe('ColocatedTemplateCompiler', function () {
               'foo.js':
                 stripIndent`
             import { hbs } from 'ember-cli-htmlbars';
-            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
             import templateOnly from '@ember/component/template-only';
 
             export default templateOnly();` + '\n',
@@ -586,7 +586,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
               import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooComponent extends Component {}
@@ -671,7 +671,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
               import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooComponent extends Component {}
@@ -790,7 +790,7 @@ describe('ColocatedTemplateCompiler', function () {
               'foo.js':
                 stripIndent`
                   import { hbs } from 'ember-cli-htmlbars';
-                  const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                  const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                   import templateOnly from '@ember/component/template-only';
 
                   export default templateOnly();` + '\n',
@@ -851,7 +851,7 @@ describe('ColocatedTemplateCompiler', function () {
               'foo.js':
                 stripIndent`
                   import { hbs } from 'ember-cli-htmlbars';
-                  const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                  const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                   import templateOnly from '@ember/component/template-only';
 
                   export default templateOnly();` + '\n',
@@ -893,7 +893,7 @@ describe('ColocatedTemplateCompiler', function () {
               'foo.js':
                 stripIndent`
                   import { hbs } from 'ember-cli-htmlbars';
-                  const __COLOCATED_TEMPLATE__ = hbs("whoops!", {"contents":"whoops!","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                  const __COLOCATED_TEMPLATE__ = hbs("whoops!", {"contents":"whoops!","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                   import templateOnly from '@ember/component/template-only';
 
                   export default templateOnly();` + '\n',
@@ -938,7 +938,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
                 import { hbs } from 'ember-cli-htmlbars';
-                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                 import Component from '@glimmer/component';
 
                 export default class FooComponent extends Component {}
@@ -980,7 +980,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
               import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("whoops!", {"contents":"whoops!","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+              const __COLOCATED_TEMPLATE__ = hbs("whoops!", {"contents":"whoops!","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooComponent extends Component {}
@@ -1026,7 +1026,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
                 import { hbs } from 'ember-cli-htmlbars';
-                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                 import Component from '@glimmer/component';
 
                 export default class FooComponent extends Component {}
@@ -1066,7 +1066,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
               import { hbs } from 'ember-cli-htmlbars';
-              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+              const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
               import Component from '@glimmer/component';
 
               export default class FooBarComponent extends Component {}
@@ -1118,7 +1118,7 @@ describe('ColocatedTemplateCompiler', function () {
             components: {
               'foo.js': stripIndent`
                 import { hbs } from 'ember-cli-htmlbars';
-                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                 import Component from '@glimmer/component';
 
                 export default class FooComponent extends Component {}
@@ -1161,7 +1161,7 @@ describe('ColocatedTemplateCompiler', function () {
               'foo.js':
                 stripIndent`
                   import { hbs } from 'ember-cli-htmlbars';
-                  const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+                  const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","meta":{"moduleName":"app-name-here/components/foo.hbs"},"parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
                   import templateOnly from '@ember/component/template-only';
 
                   export default templateOnly();` + '\n',

--- a/node-tests/colocated-test.js
+++ b/node-tests/colocated-test.js
@@ -89,7 +89,9 @@ describe('Colocation - Broccoli + Babel Integration', function () {
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
               "contents": "{{yield}}",
-              "moduleName": "app-name-here/components/foo.hbs",
+              "meta": {
+                "moduleName": "app-name-here/components/foo.hbs"
+              },
               "parseOptions": {
                 "srcName": "app-name-here/components/foo.hbs"
               }
@@ -135,7 +137,9 @@ describe('Colocation - Broccoli + Babel Integration', function () {
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
               "contents": "{{yield}}",
-              "moduleName": "app-name-here/components/foo.hbs",
+              "meta": {
+                "moduleName": "app-name-here/components/foo.hbs"
+              },
               "parseOptions": {
                 "srcName": "app-name-here/components/foo.hbs"
               }
@@ -183,7 +187,9 @@ describe('Colocation - Broccoli + Babel Integration', function () {
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
               "contents": "{{yield}}",
-              "moduleName": "app-name-here/components/foo.hbs",
+              "meta": {
+                "moduleName": "app-name-here/components/foo.hbs"
+              },
               "parseOptions": {
                 "srcName": "app-name-here/components/foo.hbs"
               }
@@ -229,7 +235,9 @@ describe('Colocation - Broccoli + Babel Integration', function () {
 
               const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
                 "contents": "{{yield}}",
-                "moduleName": "@scope-name/addon-name-here/components/foo.hbs",
+                "meta": {
+                  "moduleName": "@scope-name/addon-name-here/components/foo.hbs"
+                },
                 "parseOptions": {
                   "srcName": "@scope-name/addon-name-here/components/foo.hbs"
                 }
@@ -278,7 +286,9 @@ describe('Colocation - Broccoli + Babel Integration', function () {
 
             const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {
               "contents": "{{yield}}",
-              "moduleName": "@scope-name/addon-name-here/components/foo.hbs",
+              "meta": {
+                "moduleName": "@scope-name/addon-name-here/components/foo.hbs"
+              },
               "parseOptions": {
                 "srcName": "@scope-name/addon-name-here/components/foo.hbs"
               }

--- a/node-tests/template_compiler_test.js
+++ b/node-tests/template_compiler_test.js
@@ -53,7 +53,9 @@ describe('TemplateCompiler', function () {
 
       let source = input.readText('template.hbs');
       let expected = `export default Ember.HTMLBars.template(${htmlbarsPrecompile(source, {
-        moduleName: 'template.hbs',
+        meta: {
+          moduleName: 'template.hbs',
+        },
       })});`;
       assert.strictEqual(output.readText('template.js'), expected);
     })
@@ -69,7 +71,9 @@ describe('TemplateCompiler', function () {
 
       let source = input.readText('template.hbs');
       let expected = `export default Ember.HTMLBars.template(${htmlbarsPrecompile(source, {
-        moduleName: 'template-with-bom.hbs',
+        meta: {
+          moduleName: 'template-with-bom.hbs',
+        },
       })});`;
 
       assert.strictEqual(output.readText('template-with-bom.js'), expected);
@@ -90,7 +94,9 @@ describe('TemplateCompiler', function () {
 
       let source = input.readText('web-component-template.hbs');
       let expected = `export default Ember.HTMLBars.template(${htmlbarsPrecompile(source, {
-        moduleName: 'web-component-template.hbs',
+        meta: {
+          moduleName: 'web-component-template.hbs',
+        },
       })});`;
 
       assert.strictEqual(output.readText('web-component-template.js'), expected);
@@ -113,7 +119,9 @@ describe('TemplateCompiler', function () {
 
       let source = input.readText('web-component-template.hbs');
       let expected = `export default Ember.HTMLBars.template(${htmlbarsPrecompile(source, {
-        moduleName: 'web-component-template.hbs',
+        meta: {
+          moduleName: 'web-component-template.hbs',
+        },
       })});`;
 
       assert.strictEqual(output.readText('web-component-template.js'), expected);

--- a/tests/dummy/lib/module-name-inliner/index.js
+++ b/tests/dummy/lib/module-name-inliner/index.js
@@ -36,7 +36,7 @@ module.exports = {
               if (node.original === 'module-name-inliner') {
                 // replacing the path with a string literal, like this
                 // {{"the-module-name-here"}}
-                return builders.string(env.moduleName);
+                return builders.string(env.meta.moduleName);
               }
             },
           },


### PR DESCRIPTION
As of Ember 2.9+ (https://github.com/emberjs/ember.js/commit/237c04c62526e7ba506dad16413cb54d06882d58) the `options.moduleName` field has been moved _into_ `options.meta.moduleName` (essentially aliased there for backwards compatibility with this library). This changes the compilation process to pass `moduleName` in `meta` directly (avoiding the copying from `options`). This changes the compilation process to pass `moduleName` in `meta` directly (avoiding the copying from `options`).

Note: this may be a breaking change ATM (there are a number of AST plugins in the wild that use `env.moduleName` directly instead of `env.meta.moduleName`), in order to land this safely we'll need to add back `moduleName` on the root with a deprecation).