### PR TITLE
Pass `isProduction` to Ember template compiler.

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -60,6 +60,8 @@ module.exports = {
     // ensure that broccoli-ember-hbs-template-compiler is not processing hbs files
     registry.remove('template', 'broccoli-ember-hbs-template-compiler');
 
+    let isProduction = process.env.EMBER_ENV === 'production';
+
     // when this.parent === this.project, `this.parent.name` is a function 😭
     let parentName = typeof this.parent.name === 'function' ? this.parent.name() : this.parent.name;
 
@@ -73,7 +75,7 @@ module.exports = {
         );
 
         let shouldColocateTemplates = this._addon._shouldColocateTemplates();
-        let htmlbarsOptions = this._addon.htmlbarsOptions();
+        let htmlbarsOptions = Object.assign({ isProduction }, this._addon.htmlbarsOptions());
 
         let inputTree = debugTree(tree, '01-input');
 
@@ -87,9 +89,14 @@ module.exports = {
         return debugTree(new TemplateCompiler(inputTree, htmlbarsOptions), '03-output');
       },
 
-      precompile(string, options) {
+      precompile(string, _options) {
+        let options = _options;
         let htmlbarsOptions = this._addon.htmlbarsOptions();
         let templateCompiler = htmlbarsOptions.templateCompiler;
+
+        if (isProduction) {
+          options = Object.assign({ isProduction }, _options);
+        }
 
         return utils.template(templateCompiler, string, options);
       },
@@ -145,6 +152,8 @@ module.exports = {
     addonOptions.babel.plugins = addonOptions.babel.plugins || [];
     let babelPlugins = addonOptions.babel.plugins;
 
+    let isProduction = process.env.EMBER_ENV === 'production';
+
     // add the babel-plugin-htmlbars-inline-precompile to the list of plugins
     // used by `ember-cli-babel` addon
     if (!utils.isInlinePrecompileBabelPluginRegistered(babelPlugins)) {
@@ -156,7 +165,8 @@ module.exports = {
 
         let htmlbarsInlinePrecompilePlugin = utils.buildParalleizedBabelPlugin(
           pluginInfo,
-          templateCompilerPath
+          templateCompilerPath,
+          isProduction
         );
 
         babelPlugins.push(htmlbarsInlinePrecompilePlugin);
@@ -165,6 +175,7 @@ module.exports = {
         this.logger.debug('Prevented by these plugins: ' + pluginInfo.unparallelizableWrappers);
 
         let htmlBarsPlugin = utils.setup(pluginInfo, {
+          isProduction,
           projectConfig: this.projectConfig(),
           templateCompilerPath,
         });

--- a/lib/template-compiler-plugin.js
+++ b/lib/template-compiler-plugin.js
@@ -71,6 +71,7 @@ class TemplateCompiler extends Filter {
         'export default ' +
         utils.template(this.options.templateCompiler, stripBom(string), {
           contents: string,
+          isProduction: this.options.isProduction,
           moduleName: relativePath,
           parseOptions: {
             srcName: srcName,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,12 +46,13 @@ function isColocatedBabelPluginRegistered(plugins) {
   );
 }
 
-function buildParalleizedBabelPlugin(pluginInfo, templateCompilerPath) {
+function buildParalleizedBabelPlugin(pluginInfo, templateCompilerPath, isProduction) {
   let parallelBabelInfo = {
     requireFile: require.resolve('./require-from-worker'),
     buildUsing: 'build',
     params: {
       templateCompilerPath,
+      isProduction,
       parallelConfigs: pluginInfo.parallelConfigs,
       modules: INLINE_PRECOMPILE_MODULES,
     },
@@ -176,6 +177,7 @@ function initializeEmberENV(templateCompiler, EmberENV) {
 
 function template(templateCompiler, string, options) {
   let precompiled = templateCompiler.precompile(string, options);
+
   return 'Ember.HTMLBars.template(' + precompiled + ')';
 }
 
@@ -198,7 +200,7 @@ function setup(pluginInfo, options) {
 
   let plugin = [
     require.resolve('babel-plugin-htmlbars-inline-precompile'),
-    { precompile, modules: INLINE_PRECOMPILE_MODULES },
+    { precompile, isProduction: options.isProduction, modules: INLINE_PRECOMPILE_MODULES },
     'ember-cli-htmlbars:inline-precompile',
   ];
 

--- a/node-tests/template_compiler_test.js
+++ b/node-tests/template_compiler_test.js
@@ -59,6 +59,82 @@ describe('TemplateCompiler', function() {
     })
   );
 
+  it('invokes AST plugins', async function() {
+    let source = '{{foo-bar}}';
+    input.write({
+      'template.hbs': source,
+    });
+    let plugin = env => {
+      return {
+        name: 'fake-ast-plugin',
+
+        visitor: {
+          MustacheStatement() {
+            return env.syntax.builders.text('Huzzah!');
+          },
+        },
+      };
+    };
+
+    htmlbarsOptions.plugins = {
+      ast: [plugin],
+    };
+
+    let tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+
+    try {
+      output = createBuilder(tree);
+      await output.build();
+    } finally {
+      tree.unregisterPlugins();
+    }
+
+    let expected = `export default Ember.HTMLBars.template(${htmlbarsPrecompile(source, {
+      moduleName: 'template.hbs',
+      plugins: {
+        ast: [plugin],
+      },
+    })});`;
+
+    let outputString = output.readText('template.js');
+    assert.strictEqual(outputString, expected);
+    assert.ok(outputString.includes('Huzzah!'));
+  });
+
+  it('AST Plugins have access to `isProduction` status', async function() {
+    let source = '{{foo-bar}}';
+    input.write({
+      'template.hbs': source,
+    });
+
+    let wasProduction = false;
+    let plugin = env => {
+      wasProduction = env.isProduction;
+
+      return {
+        name: 'fake-ast-plugin',
+
+        visitor: {},
+      };
+    };
+
+    htmlbarsOptions.isProduction = true;
+    htmlbarsOptions.plugins = {
+      ast: [plugin],
+    };
+
+    let tree = new TemplateCompiler(input.path(), htmlbarsOptions);
+
+    try {
+      output = createBuilder(tree);
+      await output.build();
+    } finally {
+      tree.unregisterPlugins();
+    }
+
+    assert.ok(wasProduction);
+  });
+
   it(
     'ignores utf-8 byte order marks',
     co.wrap(function*() {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
-    "babel-plugin-htmlbars-inline-precompile": "^3.0.1",
+    "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-persistent-filter": "^2.3.1",
     "broccoli-plugin": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,10 +1645,10 @@ babel-plugin-htmlbars-inline-precompile@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
   integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
-babel-plugin-htmlbars-inline-precompile@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.0.1.tgz#e1e38a4087f446578e419a21c112530c8df02345"
-  integrity sha512-ZiFY0nQjtdMPGIDwp/5LYOs6rCr54QfcSV5nPbrA7C++Fv4Vb2Q/qrKYx78t+dwmARJztnOBlObFk4z8veHxNA==
+babel-plugin-htmlbars-inline-precompile@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz#c4882ea875d0f5683f0d91c1f72e29a4f14b5606"
+  integrity sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==
 
 babel-plugin-module-resolver@^3.1.1, babel-plugin-module-resolver@^3.2.0:
   version "3.2.0"
@@ -7098,9 +7098,8 @@ mocha@^7.1.1:
     yargs-unparser "1.6.0"
 
 "module-name-inliner@link:./tests/dummy/lib/module-name-inliner":
-  version "0.1.0"
-  dependencies:
-    ember-cli-version-checker "*"
+  version "0.0.0"
+  uid ""
 
 morgan@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
This flag allows the template compiler to have different behavior in production vs development builds.

**NOTE** this is a backport of #597 to the v4.x branch.