### PR TITLE
perf: encode template as JSON string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -189,7 +189,7 @@ function template(templateCompiler, string, options) {
   // `precompiled` is a string representing a JS object. By stringifyig it first,
   // we properly escape it, so that is can be parsed at runtime.
   // Bundling it as a string that is parsed as JSON is faster than a real JS object,
-  // as the JSON parser is much simpler and faster than the JS parser. 
+  // as the JSON parser is much simpler and faster than the JS parser.
   return 'Ember.HTMLBars.template(JSON.parse(' + JSON.stringify(precompiled) + '))';
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -186,7 +186,11 @@ function initializeEmberENV(templateCompiler, EmberENV) {
 function template(templateCompiler, string, options) {
   let precompiled = templateCompiler.precompile(string, options);
 
-  return 'Ember.HTMLBars.template(' + precompiled + ')';
+  // `precompiled` is a string representing a JS object. By stringifyig it first,
+  // we properly escape it, so that is can be parsed at runtime.
+  // Bundling it as a string that is parsed as JSON is faster than a real JS object,
+  // as the JSON parser is much simpler and faster than the JS parser. 
+  return 'Ember.HTMLBars.template(JSON.parse(' + JSON.stringify(precompiled) + '))';
 }
 
 function setup(pluginInfo, options) {


### PR DESCRIPTION
Spawned by https://discuss.emberjs.com/t/what-is-the-current-state-of-more-advanced-glimmer-vm-features/18114/2

I always assumed we were already shipping our templates as JSON, but apparently they are still plain JS objects.

I don't really know how high the impact would be, as this string is still included in a `.js` file and not side-loaded as an extra `.json` file, but at least in theory, it should yield perf improvements.