### PR TITLE
Make cacheKey lazy

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,12 +66,20 @@ function buildParalleizedBabelPlugin(
   };
 
   // parallelBabelInfo will not be used in the cache unless it is explicitly included
-  let cacheKey = makeCacheKey(templateCompilerPath, pluginInfo, JSON.stringify(parallelBabelInfo));
-
+  let cacheKey;
   return {
     _parallelBabel: parallelBabelInfo,
     baseDir: () => __dirname,
-    cacheKey: () => cacheKey,
+    cacheKey: () => {
+      if (cacheKey === undefined) {
+        cacheKey = makeCacheKey(
+          templateCompilerPath,
+          pluginInfo,
+          JSON.stringify(parallelBabelInfo)
+        );
+      }
+      return cacheKey;
+    },
   };
 }
 
@@ -196,15 +204,20 @@ function setup(pluginInfo, options) {
   let htmlbarsOptions = buildOptions(projectConfig, templateCompilerPath, pluginInfo);
   let { templateCompiler } = htmlbarsOptions;
 
-  let cacheKey = makeCacheKey(templateCompilerPath, pluginInfo);
-
   registerPlugins(templateCompiler, {
     ast: pluginInfo.plugins,
   });
 
   let { precompile } = templateCompiler;
   precompile.baseDir = () => path.resolve(__dirname, '..');
-  precompile.cacheKey = () => cacheKey;
+
+  let cacheKey;
+  precompile.cacheKey = () => {
+    if (cacheKey === undefined) {
+      cacheKey = makeCacheKey(templateCompilerPath, pluginInfo);
+    }
+    cacheKey;
+  };
 
   let plugin = [
     require.resolve('babel-plugin-htmlbars-inline-precompile'),


### PR DESCRIPTION
Right now cacheKey is eagerly made during the included hook. This is problematic if you have configuration and addons working together. This defers making the cacheKey until it is requested during build.