### PR TITLE
Ember Ember 3.27+ can determine global for template compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 10.x
     - name: install dependencies
       run: yarn install
     - name: test

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,11 +143,21 @@ function getTemplateCompiler(templateCompilerPath, EmberENV = {}) {
   // the shared global config
   let clonedEmberENV = JSON.parse(JSON.stringify(EmberENV));
 
-  let context = vm.createContext({
+  let sandbox = {
     EmberENV: clonedEmberENV,
     module: { require, exports: {} },
     require,
-  });
+  };
+
+  // if we are running on a Node version _without_ a globalThis
+  // we must provide a `global`
+  //
+  // this is due to https://git.io/Jtb7s (Ember 3.27+)
+  if (typeof globalThis === 'undefined') {
+    sandbox.global = sandbox;
+  }
+
+  let context = vm.createContext(sandbox);
 
   script.runInContext(context);
 


### PR DESCRIPTION
Ensure Ember 3.27+ can determine global for template compilation.

Node 12+ has access to `globalThis` (including within a VM context), but older versions do not.

Due to the detection done in https://git.io/Jtb7s, when we can't find `globalThis` (and don't define `global` global) evaluating `ember-template-compiler.js` throws an error "unable to locate global object".

This ensures that either `globalThis` or `global` are defined.

Fixes https://github.com/emberjs/ember.js/issues/19431
