### PR TITLE
Ensure AST plugins have the same ordering as < ember-cli-htmlbars@5.5.0.

### DIFF
--- a/lib/template-compiler-plugin.js
+++ b/lib/template-compiler-plugin.js
@@ -52,6 +52,17 @@ class TemplateCompiler extends Filter {
     let srcDir = this.inputPaths[0];
     let srcName = path.join(srcDir, relativePath);
     try {
+      // we have to reverse these for reasons that are a bit bonkers. the initial
+      // version of this system used `registeredPlugin` from
+      // `ember-template-compiler.js` to set up these plugins (because Ember ~ 1.13
+      // only had `registerPlugin`, and there was no way to pass plugins directly
+      // to the call to `compile`/`precompile`). calling `registerPlugin`
+      // unfortunately **inverted** the order of plugins (it essentially did
+      // `PLUGINS = [plugin, ...PLUGINS]`).
+      //
+      // sooooooo...... we are forced to maintain that **absolutely bonkers** ordering
+      let astPlugins = this.options.plugins ? [...this.options.plugins.ast].reverse() : [];
+
       let result =
         'export default ' +
         utils.template(this.options.templateCompiler, stripBom(string), {
@@ -67,7 +78,7 @@ class TemplateCompiler extends Filter {
           // all of the built in AST transforms into plugins.ast, which breaks
           // persistent caching)
           plugins: {
-            ast: this.options.plugins ? this.options.plugins.ast : [],
+            ast: astPlugins,
           },
         }) +
         ';';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -208,9 +208,20 @@ function setup(pluginInfo, options) {
   let templatePrecompile = templateCompiler.precompile;
 
   let precompile = (template, _options) => {
+    // we have to reverse these for reasons that are a bit bonkers. the initial
+    // version of this system used `registeredPlugin` from
+    // `ember-template-compiler.js` to set up these plugins (because Ember ~ 1.13
+    // only had `registerPlugin`, and there was no way to pass plugins directly
+    // to the call to `compile`/`precompile`). calling `registerPlugin`
+    // unfortunately **inverted** the order of plugins (it essentially did
+    // `PLUGINS = [plugin, ...PLUGINS]`).
+    //
+    // sooooooo...... we are forced to maintain that **absolutely bonkers** ordering
+    let astPlugins = [...pluginInfo.plugins].reverse();
+
     let options = {
       plugins: {
-        ast: pluginInfo.plugins,
+        ast: astPlugins,
       },
     };
 


### PR DESCRIPTION
We have to reverse these for reasons that are a bit bonkers. The initial version of this system used `registeredPlugin` from `ember-template-compiler.js` to set up these plugins (because Ember ~ 1.13 only had `registerPlugin`, and there was no way to pass plugins directly to the call to `compile`/`precompile`). Calling `registerPlugin` unfortunately **inverted** the order of plugins (it essentially did `PLUGINS = [plugin, ...PLUGINS]`).

Sooooooo...... we are forced to maintain that **absolutely bonkers** ordering.

This _should_ address https://github.com/ember-cli/ember-cli-htmlbars/issues/664, but I'd like to leave it open so @simonihmig can confirm.
