### PR TITLE
Support TypeScript merging of export default declarations in template colocation

### DIFF
--- a/lib/colocated-babel-plugin.js
+++ b/lib/colocated-babel-plugin.js
@@ -22,7 +22,15 @@ module.exports = function (babel) {
       },
 
       ExportDefaultDeclaration(path, state) {
-        if (state.colocatedTemplateFound !== true || state.setComponentTemplateInjected === true) {
+        let defaultExportDeclarationPath = path.get('declaration');
+        let defaultExportIsExpressionOrClass =
+          defaultExportDeclarationPath.isClass() || defaultExportDeclarationPath.isExpression();
+
+        if (
+          state.colocatedTemplateFound !== true ||
+          state.setComponentTemplateInjected === true ||
+          !defaultExportIsExpressionOrClass
+        ) {
           return;
         }
 

--- a/lib/colocated-babel-plugin.js
+++ b/lib/colocated-babel-plugin.js
@@ -24,7 +24,9 @@ module.exports = function (babel) {
       ExportDefaultDeclaration(path, state) {
         let defaultExportDeclarationPath = path.get('declaration');
         let defaultExportIsExpressionOrClass =
-          defaultExportDeclarationPath.isClass() || defaultExportDeclarationPath.isExpression() || defaultExportDeclarationPath.isFunction();
+          defaultExportDeclarationPath.isClass() ||
+          defaultExportDeclarationPath.isExpression() ||
+          defaultExportDeclarationPath.isFunction();
 
         if (
           state.colocatedTemplateFound !== true ||

--- a/lib/colocated-babel-plugin.js
+++ b/lib/colocated-babel-plugin.js
@@ -24,7 +24,7 @@ module.exports = function (babel) {
       ExportDefaultDeclaration(path, state) {
         let defaultExportDeclarationPath = path.get('declaration');
         let defaultExportIsExpressionOrClass =
-          defaultExportDeclarationPath.isClass() || defaultExportDeclarationPath.isExpression();
+          defaultExportDeclarationPath.isClass() || defaultExportDeclarationPath.isExpression() || defaultExportDeclarationPath.isFunction();
 
         if (
           state.colocatedTemplateFound !== true ||


### PR DESCRIPTION
In TypeScript it's possible to merge together multiple interfaces by redeclaring them, and one occasional use for this is to declare that a class meets a certain interface in a way that isn't statically visible (such as the way `@ember/component`s "implement" their args by splatting them on to the instance).

For a default export, though, this can result in multiple `ExportDefaultDeclaration`s in one module:
```ts
import Component from '@ember/component';

type MyComponentArgs = { required: string; optional?: number };

export default interface MyComponent extends MyComponentArgs {}
export default class MyComponent extends Component {
  // ...
}
```

This is legal (since the TS plugin ultimately strips out the interface), but currently causes an error in the colocation plugin because we try to associate the template with the interface declaration rather than the class:

```
TypeError: unknown: 
  Property arguments[1] of CallExpression expected node to be of a type ["Expression","SpreadElement","JSXNamespacedName","ArgumentPlaceholder"] but instead got "TSInterfaceDeclaration"
```

This PR adds a check to ensure that the item we're attempting to associate the template to is either a class declaration or an expression so that we correctly skip the interface.