### PR TITLE
Make `setTimeout`/`clearTimeout` available to the template compiler sandbox

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,6 +145,13 @@ function getTemplateCompiler(templateCompilerPath, EmberENV = {}) {
 
   let sandbox = {
     EmberENV: clonedEmberENV,
+
+    // Older versions of ember-template-compiler (up until ember-source@3.1.0)
+    // eagerly access `setTimeout` without checking via `typeof` first
+    setTimeout,
+    clearTimeout,
+
+    // fake the module into thinking we are running inside a Node context
     module: { require, exports: {} },
     require,
   };


### PR DESCRIPTION
We do not directly support these older Ember versions, but apparently we also didn't warn/error if you used them so folks happily updated to 5.x while still supporting Ember 2.x. This is largely just "being nice" and trying to avoid breaking folks accidentally.

A follow up PR should issue a warning when using Ember versions older than the ones that we explicitly support.
