### PR TITLE
Pass useEmberModule option to plugins

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -110,7 +110,12 @@ module.exports = {
         if (shouldColocateTemplates) {
           const ColocatedTemplateProcessor = require('./colocated-broccoli-plugin');
 
-          inputTree = debugTree(new ColocatedTemplateProcessor(inputTree), '02-colocated-output');
+          inputTree = debugTree(
+            new ColocatedTemplateProcessor(inputTree, {
+              useEmberModule: this._addon._shouldUseEmberModule(),
+            }),
+            '02-colocated-output'
+          );
         }
 
         this._addon.logger.debug(`setup *.hbs compiler with ${htmlbarsOptions.pluginNames}`);

--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -57,6 +57,25 @@ module.exports = {
     return this._cachedShouldColocateTemplates;
   },
 
+  _shouldUseEmberModule() {
+    if (this._cachedShouldUseEmberModule) {
+      return this._cachedShouldUseEmberModule;
+    }
+
+    const semver = require('semver');
+    let ember = this.project.addons.find((a) => a.name === 'ember-source');
+    let hasEmberSource = ember !== undefined;
+    let emberVersion = hasEmberSource && ember.pkg.version;
+
+    this._cachedShouldUseEmberModule = hasEmberSource && semver.gte(emberVersion, '3.27.0-alpha.1');
+
+    this.logger.info(
+      `useEmberModule processing: ${this._cachedShouldUseEmberModule} (emberVersion: ${emberVersion})`
+    );
+
+    return this._cachedShouldUseEmberModule;
+  },
+
   // This method is monkey patched by CSS Blocks,
   // Please coordinate with @chriseppstein if you need to change it.
   transpileTree(inputTree, htmlbarsOptions) {
@@ -190,7 +209,8 @@ module.exports = {
           this.projectConfig(),
           templateCompilerPath,
           isProduction,
-          customModules
+          customModules,
+          this._shouldUseEmberModule()
         );
 
         babelPlugins.push(htmlbarsInlinePrecompilePlugin);
@@ -205,6 +225,7 @@ module.exports = {
           projectConfig: this.projectConfig(),
           templateCompilerPath,
           modules: customModules,
+          useEmberModule: this._shouldUseEmberModule(),
         });
 
         babelPlugins.push(htmlBarsPlugin);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,8 @@ function buildParalleizedBabelPlugin(
   projectConfig,
   templateCompilerPath,
   isProduction,
-  customModules
+  customModules,
+  useEmberModule
 ) {
   let parallelBabelInfo = {
     requireFile: require.resolve('./require-from-worker'),
@@ -71,6 +72,7 @@ function buildParalleizedBabelPlugin(
       projectConfig,
       parallelConfigs: pluginInfo.parallelConfigs,
       modules: Object.assign({}, customModules, INLINE_PRECOMPILE_MODULES),
+      useEmberModule,
     },
   };
 
@@ -262,6 +264,7 @@ function setup(pluginInfo, options) {
       precompile,
       isProduction: options.isProduction,
       ensureModuleApiPolyfill: true,
+      useEmberModule: options.useEmberModule,
       modules: Object.assign({}, options.modules, INLINE_PRECOMPILE_MODULES),
     },
     'ember-cli-htmlbars:inline-precompile',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
-    "babel-plugin-htmlbars-inline-precompile": "^4.4.1",
+    "babel-plugin-htmlbars-inline-precompile": "^4.4.5",
     "broccoli-debug": "^0.6.5",
     "broccoli-persistent-filter": "^3.1.2",
     "broccoli-plugin": "^4.0.3",
@@ -76,7 +76,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.25.0",
+    "ember-source": "~3.27.0-alpha.2",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.9.1",
     "ember-try": "^1.4.0",
@@ -119,5 +119,8 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "ember": {
+    "edition": "octane"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,10 +1184,10 @@
     "@glimmer/interfaces" "^0.54.1"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/vm-babel-plugins@0.74.2":
-  version "0.74.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.74.2.tgz#479774d5885201538245f4cba76cabd4b0dee3a5"
-  integrity sha512-DLIKzim7Fg3o54EPgz/wsEiLOUcg24P4WJ9AAv4xsXfBmFndkEDzq1oJ3SPhB167Vp1m+GKOlfKzFm9mxX5rdA==
+"@glimmer/vm-babel-plugins@0.77.1":
+  version "0.77.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.1.tgz#80c8b5476ccff68191bc42ebb29928a9b8d22d69"
+  integrity sha512-amkBPV3H/3OhYIeXo03sU1VzqmUl8TUxHhjfVJwRy+vQV22S5saZCiUCyOYUsUkxdEG5sU8qooooBY8VomkkBg==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
@@ -2190,10 +2190,10 @@ babel-plugin-htmlbars-inline-precompile@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
   integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
-babel-plugin-htmlbars-inline-precompile@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.4.1.tgz#2ec5282cdc92bd5b5ad918a8ddc4cd0a261b5187"
-  integrity sha512-OCdeSw08LkMhRWE4n35BZX/lt2bKdDHUfZlqjSd0sJN0zkm0KG6JyWMlqnq8h52pNiKkgYvq/gUqONkM0JqcmQ==
+babel-plugin-htmlbars-inline-precompile@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.4.5.tgz#ca0fc6ea49fe13b0a91ff995ee381d33d421a4ef"
+  integrity sha512-7qnZTDm9uUQppOmEWjAyIPTQ54akEdd9PCIfbTJ8HNgUdekeKC+24uwd+M1ZTjUItby1iLy9maQOK3Wv9RjWJA==
   dependencies:
     babel-plugin-ember-modules-api-polyfill "^3.4.0"
 
@@ -4643,16 +4643,16 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.25.0:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.25.1.tgz#7621fe7d471d08045b95c79fc760c3ca44efce4f"
-  integrity sha512-WCQV3FqbXRkYAwrwLZ6QcHZcTjT9ESa9H8Il+5H0QmDxLPiFnaj/UW4YLgZZ64X9PBT9WCUzLeLcccIFoFFm7w==
+ember-source@~3.27.0-alpha.2:
+  version "3.27.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.27.0-alpha.2.tgz#8e12a9359363ac3f86a41719db2b13147fd4b79b"
+  integrity sha512-y0CshJ8J+IZPdIRR0lDgoGhIjGpLy8ZfMtU8ZMNY/4RzUm6oAjDSwjN1NeUe+6jPpqY8YAEkdf64u7eFX3wuJQ==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
     "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
-    "@glimmer/vm-babel-plugins" "0.74.2"
+    "@glimmer/vm-babel-plugins" "0.77.1"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     broccoli-concat "^4.2.4"
@@ -4669,9 +4669,9 @@ ember-source@~3.25.0:
     ember-cli-version-checker "^5.1.1"
     ember-router-generator "^2.0.0"
     inflection "^1.12.0"
-    jquery "^3.5.0"
+    jquery "^3.5.1"
     resolve "^1.17.0"
-    semver "^6.1.1"
+    semver "^7.3.4"
     silent-error "^1.1.1"
 
 ember-template-lint@^2.9.1:
@@ -6963,10 +6963,10 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery@^3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+jquery@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-reporters@1.2.1:
   version "1.2.1"
@@ -7877,7 +7877,8 @@ mocha@^8.3.0:
     yargs-unparser "2.0.0"
 
 "module-name-inliner@link:./tests/dummy/lib/module-name-inliner":
-  version "0.1.0"
+  version "0.0.0"
+  uid ""
 
 morgan@^1.10.0:
   version "1.10.0"
@@ -9428,7 +9429,7 @@ semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
I'm just working my way through various things here and pushing up what I have so far to help get myself unblocked.

1. It appears we require a new release of ember-cli-babel with https://github.com/babel/ember-cli-babel/pull/385 (as it has an upgrade of `babel-plugin-ember-modules-api-polyfill`) because it looks like the imports mismatch in tests (imports `_ember2` but uses `_ember`) instead. We require an upgrade of 
![image](https://user-images.githubusercontent.com/685034/111217867-f4654700-85cd-11eb-997f-5f91154cde7f.png)

2. Colocated components don't appear to be transformed from using the global Ember
![image](https://user-images.githubusercontent.com/685034/111217998-18c12380-85ce-11eb-978c-562a6bbf9ebc.png)
