### PR TITLE
Ensure global is present for Node 10 + globalThis polyfill

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,6 +118,23 @@ function buildOptions(projectConfig, templateCompilerPath, pluginInfo) {
   return htmlbarsOptions;
 }
 
+const hasGlobalThis = (function () {
+  try {
+    let context = vm.createContext();
+
+    // we must create a sandboxed context to test if `globalThis` will be
+    // present _within_ it because in some contexts a globalThis polyfill has
+    // been evaluated. In that case globalThis would be available on the
+    // current global context but **would not** be inherited to the global
+    // contexts created by `vm.createContext`
+    let type = vm.runInContext(`typeof globalThis`, context);
+
+    return type !== 'undefined';
+  } catch (e) {
+    return false;
+  }
+})();
+
 function getTemplateCompiler(templateCompilerPath, EmberENV = {}) {
   let templateCompilerFullPath = require.resolve(templateCompilerPath);
   let cacheData = TemplateCompilerCache.get(templateCompilerFullPath);
@@ -164,7 +181,7 @@ function getTemplateCompiler(templateCompilerPath, EmberENV = {}) {
   // we must provide a `global`
   //
   // this is due to https://git.io/Jtb7s (Ember 3.27+)
-  if (typeof globalThis === 'undefined') {
+  if (!hasGlobalThis) {
     sandbox.global = sandbox;
   }
 


### PR DESCRIPTION
The prior method (`typeof globalThis` in the currently running context) cannot properly indicate if `globalThis` will be available within the sandboxed context.
