### PR TITLE
add `this._super` call to included hook plugin doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ module.exports = {
       name: 'some-transform',
       plugin: SomeTransform
     });
+    
+    this._super.included.apply(this, arguments);
   }
 };
 ```


### PR DESCRIPTION
Not calling `this._super` in the `included` hook causes other build issues (at least when developing an addon)
and seems to be the recommended practice in the docs as well:

https://cli.emberjs.com/release/writing-addons/in-repo-addons/#broccolibuildoptionsforinrepoaddons