### PR TITLE
Avoid repeated encoding in getTemplateCompiler

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,14 +140,14 @@ function getTemplateCompiler(templateCompilerPath, EmberENV = {}) {
   let cacheData = TemplateCompilerCache.get(templateCompilerFullPath);
 
   if (cacheData === undefined) {
-    let templateCompilerContents = fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' });
+    let templateCompilerContents = fs.readFileSync(templateCompilerFullPath);
     let templateCompilerCacheKey = crypto
       .createHash('md5')
       .update(templateCompilerContents)
       .digest('hex');
 
     cacheData = {
-      script: new vm.Script(templateCompilerContents, {
+      script: new vm.Script(templateCompilerContents.toString(), {
         filename: templateCompilerPath,
       }),
 


### PR DESCRIPTION
`crypto.createHash('md5').update(...)` takes a buffer. The prior code would read the file as a string _then_ convert back to a buffer. Now we only convert to a string for `new vm.Script()` which _requires_ a string. tldr; we convert back and forth from a buffer to a string one less time with the code change here.