### PR TITLE
Allow console messages (v5.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,8 @@ jobs:
          - ember-lts-3.8
          - ember-lts-3.12
          - ember-lts-3.16
-         - ember-release
+         - ember-lts-3.28
          - ember-octane
-         - ember-beta
-         - ember-canary
          - ember-default-with-jquery
          - with-ember-cli-htmlbars-inline-precompile
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -36,10 +36,23 @@ module.exports = function () {
           },
         },
         {
+          name: 'ember-lts-3.28',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.28.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {
+              'ember-auto-import': '^2.2.3',
               'ember-source': urls[0],
+              webpack: '^5.52.1',
+            },
+            ember: {
+              edition: 'octane',
             },
           },
         },
@@ -47,7 +60,12 @@ module.exports = function () {
           name: 'ember-beta',
           npm: {
             devDependencies: {
+              'ember-auto-import': '^2.2.3',
               'ember-source': urls[1],
+              webpack: '^5.52.1',
+            },
+            ember: {
+              edition: 'octane',
             },
           },
         },
@@ -55,7 +73,12 @@ module.exports = function () {
           name: 'ember-canary',
           npm: {
             devDependencies: {
+              'ember-auto-import': '^2.2.3',
               'ember-source': urls[2],
+              webpack: '^5.52.1',
+            },
+            ember: {
+              edition: 'octane',
             },
           },
         },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -166,6 +166,7 @@ function getTemplateCompiler(templateCompilerPath, EmberENV = {}) {
 
   let sandbox = {
     EmberENV: clonedEmberENV,
+    console,
 
     // Older versions of ember-template-compiler (up until ember-source@3.1.0)
     // eagerly access `setTimeout` without checking via `typeof` first


### PR DESCRIPTION
A copy of https://github.com/ember-cli/ember-cli-htmlbars/pull/739 targeting a 5.x release branch.

Also fixes CI. This *removes* Ember 4 from CI as it fails on `LegacyPlugin cannot be invoked without 'new'`. See https://github.com/ember-cli/ember-cli-htmlbars/runs/4419325026?check_suite_focus=true#step:5:146 It isn't clear if v5.x was expected to support Ember 4 or not. Based on CI, it does not, and so I've removed it from CI while leaving it in the try config.