### PR TITLE
Fix incorrect ember-source version check

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -170,7 +170,7 @@ module.exports = {
 
     let isProduction = process.env.EMBER_ENV === 'production';
 
-    let checker = new VersionChecker(this.parent).for('ember-source', 'npm');
+    let checker = new VersionChecker(this.project).for('ember-source', 'npm');
     this._requiresModuleApiPolyfill = checker.exists() && checker.lt('3.27.0-alpha.1');
 
     // add the babel-plugin-htmlbars-inline-precompile to the list of plugins


### PR DESCRIPTION
Found this bug in a monorepo setup with multiple apps, where one app was using an older version (3.26, so needed the modules API polyfill) while the others were on 3.28. With most dependencies being hoisted in the central `/node_modules`, for any addon that depends on ember-cli-htmlbars it would find the wrong ember-source package, namely `/node_modules/ember-source` (3.28) instead of `apps/foo-app/node_modules/ember-source` (the correct 3.26 version).

Fixes #687