### PR TITLE
Avoid registering `babel-plugin-ember-template-compilation` repeatedly

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,13 +25,17 @@ const INLINE_PRECOMPILE_MODULES = Object.freeze({
 function isInlinePrecompileBabelPluginRegistered(plugins) {
   return plugins.some((plugin) => {
     if (Array.isArray(plugin)) {
-      let [pluginPathOrInstance, options] = plugin;
-
-      return (
+      let [pluginPathOrInstance, options, key] = plugin;
+      let isHTMLBarsInlinePrecompile =
         pluginPathOrInstance === require.resolve('babel-plugin-htmlbars-inline-precompile') &&
         typeof options.modules === 'object' &&
-        options.modules['ember-cli-htmlbars'] === 'hbs'
-      );
+        options.modules['ember-cli-htmlbars'] === 'hbs';
+
+      let isEmberTemplateCompilation =
+        pluginPathOrInstance === require.resolve('babel-plugin-ember-template-compilation') &&
+        key === 'ember-cli-htmlbars:inline-precompile';
+
+      return isHTMLBarsInlinePrecompile || isEmberTemplateCompilation;
     } else if (
       plugin !== null &&
       typeof plugin === 'object' &&

--- a/node-tests/utils_test.js
+++ b/node-tests/utils_test.js
@@ -166,6 +166,36 @@ describe('utils', function () {
     });
   });
 
+  describe('isInlinePrecompileBabelPluginRegistered', function () {
+    it('is false when no plugins exist', function () {
+      let plugins = [];
+
+      assert.strictEqual(utils.isInlinePrecompileBabelPluginRegistered(plugins), false);
+    });
+
+    it('detects when the htmlbars-inline-precompile plugin exists', function () {
+      let plugins = [
+        utils.setup({}, { requiresModuleApiPolyfill: true, templateCompilerPath: '.' }),
+      ];
+
+      assert.strictEqual(utils.isInlinePrecompileBabelPluginRegistered(plugins), true);
+    });
+
+    it('detects when the ember-template-compilation plugin exists', function () {
+      let plugins = [
+        utils.setup({}, { requiresModuleApiPolyfill: false, templateCompilerPath: '.' }),
+      ];
+
+      assert.strictEqual(utils.isInlinePrecompileBabelPluginRegistered(plugins), true);
+    });
+
+    it('detects when the parallelized plugin exists', function () {
+      let plugins = [utils.buildParalleizedBabelPlugin({}, {}, '', false, true)];
+
+      assert.strictEqual(utils.isInlinePrecompileBabelPluginRegistered(plugins), true);
+    });
+  });
+
   describe('isColocatedBabelPluginRegistered', function () {
     it('is false when no plugins exist', function () {
       let plugins = [];


### PR DESCRIPTION
I'm looking at upgrading an app to Ember 3.28, and am running into issues where `babel-plugin-ember-template-compilation` is being registered multiple times.

It looks like the `isInlinePrecompileBabelPluginRegistered` utility function here is meant to act as a generic "have we already installed our plugin" guard, but it wasn't updated when the new Babel plugin was introduced for the post-modules-polyfill world.

Based on @nightire's comment on https://github.com/ember-cli/ember-cli-htmlbars/issues/297#issuecomment-1101970035, I wonder if this might be what they're running into as well? Our app also has `ember-engines` as a dependency, and I've confirmed locally that this change eliminates the "duplicate Babel plugin" error I was seeing.