### PR TITLE
Upgrade to `babel-plugin-ember-template-compilation` v2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,45 +196,43 @@ function setup(pluginInfo, options) {
 
   let htmlbarsOptions = buildOptions(projectConfig, templateCompilerPath, pluginInfo);
   let { templateCompiler } = htmlbarsOptions;
+  if (options.requiresModuleApiPolyfill) {
+    let templatePrecompile = templateCompiler.precompile;
 
-  let templatePrecompile = templateCompiler.precompile;
+    let precompile = (template, _options) => {
+      // we have to reverse these for reasons that are a bit bonkers. the initial
+      // version of this system used `registeredPlugin` from
+      // `ember-template-compiler.js` to set up these plugins (because Ember ~ 1.13
+      // only had `registerPlugin`, and there was no way to pass plugins directly
+      // to the call to `compile`/`precompile`). calling `registerPlugin`
+      // unfortunately **inverted** the order of plugins (it essentially did
+      // `PLUGINS = [plugin, ...PLUGINS]`).
+      //
+      // sooooooo...... we are forced to maintain that **absolutely bonkers** ordering
+      let astPlugins = [...pluginInfo.plugins].reverse();
 
-  let precompile = (template, _options) => {
-    // we have to reverse these for reasons that are a bit bonkers. the initial
-    // version of this system used `registeredPlugin` from
-    // `ember-template-compiler.js` to set up these plugins (because Ember ~ 1.13
-    // only had `registerPlugin`, and there was no way to pass plugins directly
-    // to the call to `compile`/`precompile`). calling `registerPlugin`
-    // unfortunately **inverted** the order of plugins (it essentially did
-    // `PLUGINS = [plugin, ...PLUGINS]`).
-    //
-    // sooooooo...... we are forced to maintain that **absolutely bonkers** ordering
-    let astPlugins = [...pluginInfo.plugins].reverse();
+      let options = {
+        plugins: {
+          ast: astPlugins,
+        },
 
-    let options = {
-      plugins: {
-        ast: astPlugins,
-      },
+        ..._options,
+      };
 
-      ..._options,
+      return templatePrecompile(template, options);
     };
 
-    return templatePrecompile(template, options);
-  };
+    precompile.baseDir = () => path.resolve(__dirname, '..');
 
-  precompile.baseDir = () => path.resolve(__dirname, '..');
+    let cacheKey;
+    precompile.cacheKey = () => {
+      if (cacheKey === undefined) {
+        cacheKey = makeCacheKey(templateCompilerPath, pluginInfo);
+      }
+      cacheKey;
+    };
 
-  let cacheKey;
-  precompile.cacheKey = () => {
-    if (cacheKey === undefined) {
-      cacheKey = makeCacheKey(templateCompilerPath, pluginInfo);
-    }
-    cacheKey;
-  };
-
-  let plugin;
-  if (options.requiresModuleApiPolyfill) {
-    plugin = [
+    return [
       require.resolve('babel-plugin-htmlbars-inline-precompile'),
       {
         precompile,
@@ -245,10 +243,12 @@ function setup(pluginInfo, options) {
       'ember-cli-htmlbars:inline-precompile',
     ];
   } else {
-    plugin = [
+    return [
       require.resolve('babel-plugin-ember-template-compilation'),
       {
-        precompile,
+        // As above, we present the AST transforms in reverse order
+        transforms: [...pluginInfo.plugins].reverse(),
+        compilerPath: require.resolve(templateCompilerPath),
         enableLegacyModules: [
           'ember-cli-htmlbars',
           'ember-cli-htmlbars-inline-precompile',
@@ -258,8 +258,6 @@ function setup(pluginInfo, options) {
       'ember-cli-htmlbars:inline-precompile',
     ];
   }
-
-  return plugin;
 }
 
 function getTemplateCompilerCacheKey(templateCompilerPath) {

--- a/node-tests/utils_test.js
+++ b/node-tests/utils_test.js
@@ -153,7 +153,10 @@ describe('utils', function () {
 
     it('detects when the ember-template-compilation plugin exists', function () {
       let plugins = [
-        utils.setup({}, { requiresModuleApiPolyfill: false, templateCompilerPath: '.' }),
+        utils.setup(
+          { plugins: [] },
+          { requiresModuleApiPolyfill: false, templateCompilerPath: '.' }
+        ),
       ];
 
       assert.strictEqual(utils.isInlinePrecompileBabelPluginRegistered(plugins), true);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
-    "babel-plugin-ember-template-compilation": "^1.0.0",
+    "babel-plugin-ember-template-compilation": "^2.0.0",
     "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-persistent-filter": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3441,10 +3441,10 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-import-util@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-0.2.0.tgz#b468bb679919601a3570f9e317536c54f2862e23"
-  integrity sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==
+babel-import-util@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.3.0.tgz#dc9251ea39a7747bd586c1c13b8d785a42797f8e"
+  integrity sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==
 
 babel-loader@^8.0.6:
   version "8.2.2"
@@ -3512,15 +3512,12 @@ babel-plugin-ember-modules-api-polyfill@^3.5.0:
   dependencies:
     ember-rfc176-data "^0.3.17"
 
-babel-plugin-ember-template-compilation@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.0.tgz#984bc2ceb0bb864e878e25a9ca5c2a6153c96881"
-  integrity sha512-SvDQ+DbimZEq7XZztxiCKPNO3/HEwAOKBdJ9r4qtMpgmSuuhzO1elkixJTrnwnkLv1titAYAXNqLVD1fkE4Vgg==
+babel-plugin-ember-template-compilation@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.0.tgz#41d895874ba6119dd461f61993c16d1154bf8a57"
+  integrity sha512-d+4jaB2ik0rt9TH0K9kOlKJeRBHEb373FgFMcU9ZaJL2zYuVXe19bqy+cWlLpLf1tpOBcBG9QTlFBCoImlOt1g==
   dependencies:
-    babel-import-util "^0.2.0"
-    line-column "^1.0.2"
-    magic-string "^0.25.7"
-    string.prototype.matchall "^4.0.5"
+    babel-import-util "^1.3.0"
 
 babel-plugin-filter-imports@^4.0.0:
   version "4.0.0"
@@ -13583,7 +13580,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string.prototype.matchall@^4.0.4, string.prototype.matchall@^4.0.5:
+string.prototype.matchall@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz#5abb5dabc94c7b0ea2380f65ba610b3a544b15fa"
   integrity sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==


### PR DESCRIPTION
The 2.0 release of `babel-plugin-ember-template-compilation` introduces the ability for template AST transforms to [manipulate JS scope](https://github.com/emberjs/babel-plugin-ember-template-compilation/pull/5), but it also reworked the plugin's options format slightly, so we need to adjust how we configure it here.

Note: this diff is more legible with the "Hide whitespace changes" button, as a fair chunk of change in `utils.js` is moving logic we no longer need for `babel-plugin-ember-template-compilation` under the other arm of the surrounding conditional.

I've tested this out in a couple medium-sized projects that are on Ember 3.27+, but I'd love extra 👀 (particularly from @ef4)