### PR TITLE
Ensure co-located templates with re-exported class do not throw an error

### DIFF
--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -150,7 +150,10 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
           }
         );
 
-        if (hasTemplate && !jsContents.includes('export default')) {
+        if (hasTemplate && jsContents.includes('export { default }')) {
+          jsContents = jsContents.replace('export { default }', 'import __Component');
+          jsContents += '\n\nexport default class extends __Component {}';
+        } else if (hasTemplate && !jsContents.includes('export default')) {
           let message = `\`${relativePath}\` does not contain a \`default export\`. Did you forget to export the component class?`;
           jsContents = `${jsContents}\nthrow new Error(${JSON.stringify(message)});`;
           prefix = '';

--- a/node-tests/colocated-broccoli-plugin-test.js
+++ b/node-tests/colocated-broccoli-plugin-test.js
@@ -186,6 +186,62 @@ describe('ColocatedTemplateCompiler', function () {
     );
   });
 
+  it('works for re-exported component with a template', async function () {
+    input.write({
+      'app-name-here': {
+        'router.js': '// stuff here',
+        components: {
+          'foo.hbs': `{{yield}}`,
+          'foo.js': `export { default } from 'some-place';`,
+        },
+        templates: {
+          'application.hbs': `{{outlet}}`,
+        },
+      },
+    });
+
+    let tree = new ColocatedTemplateCompiler(input.path());
+
+    output = createBuilder(tree);
+    await output.build();
+
+    assert.deepStrictEqual(output.read(), {
+      'app-name-here': {
+        'router.js': '// stuff here',
+        components: {
+          'foo.js': stripIndent`
+            import { hbs } from 'ember-cli-htmlbars';
+            const __COLOCATED_TEMPLATE__ = hbs("{{yield}}", {"contents":"{{yield}}","moduleName":"app-name-here/components/foo.hbs","parseOptions":{"srcName":"app-name-here/components/foo.hbs"}});
+            import __Component from 'some-place';
+
+            export default class extends __Component {}
+          `,
+        },
+        templates: {
+          'application.hbs': '{{outlet}}',
+        },
+      },
+    });
+
+    await output.build();
+
+    assert.deepStrictEqual(output.changes(), {}, 'NOOP update has no changes');
+
+    input.write({
+      'app-name-here': {
+        'router.js': '// other stuff here',
+      },
+    });
+
+    await output.build();
+
+    assert.deepStrictEqual(
+      output.changes(),
+      { 'app-name-here/router.js': 'change' },
+      'has only related changes'
+    );
+  });
+
   it('works for typescript component class with template', async function () {
     input.write({
       'app-name-here': {


### PR DESCRIPTION
Fixes https://github.com/ember-cli/ember-cli-htmlbars/issues/771. I did try avoiding the error that throws the error by adding `&& !jsContents.includes('export { default }')`, but that doesn't work for re-exports (doesn't surprise me). So, I made it work such that it turns
```js
export { default } from 'some-place';
```
into
```js
import Component from 'some-place';

export default class extends Component {}
```
and then it works. I added a test for this as well, and I also verified it works in practice by locally linking the package within our application.