### PR TITLE
Adjust error message for re-exported class when it has a co-located template

### DIFF
--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -150,8 +150,12 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
           }
         );
 
-        if (hasTemplate && !jsContents.includes('export default')) {
-          let message = `\`${relativePath}\` does not contain a \`default export\`. Did you forget to export the component class?`;
+        if (hasTemplate && jsContents.includes('export { default }')) {
+          let message = `\`${backingClassPath}\` contains an \`export { default }\` re-export, but it has a co-located template. You must explicitly extend the component to assign it a different template.`;
+          jsContents = `${jsContents}\nthrow new Error(${JSON.stringify(message)});`;
+          prefix = '';
+        } else if (hasTemplate && !jsContents.includes('export default')) {
+          let message = `\`${backingClassPath}\` does not contain a \`default export\`. Did you forget to export the component class?`;
           jsContents = `${jsContents}\nthrow new Error(${JSON.stringify(message)});`;
           prefix = '';
         }

--- a/node-tests/colocated-test.js
+++ b/node-tests/colocated-test.js
@@ -407,7 +407,7 @@ describe('Colocation - Broccoli + Babel Integration (modules API: true)', functi
       'app-name-here': {
         components: {
           'foo.js': stripIndent`
-            export function whatever() {}\nthrow new Error("\`app-name-here/components/foo.hbs\` does not contain a \`default export\`. Did you forget to export the component class?");
+            export function whatever() {}\nthrow new Error("\`app-name-here/components/foo.js\` does not contain a \`default export\`. Did you forget to export the component class?");
           `,
         },
       },
@@ -797,7 +797,7 @@ describe('Colocation - Broccoli + Babel Integration (modules API: false)', funct
       'app-name-here': {
         components: {
           'foo.js': stripIndent`
-            export function whatever() {}\nthrow new Error("\`app-name-here/components/foo.hbs\` does not contain a \`default export\`. Did you forget to export the component class?");
+            export function whatever() {}\nthrow new Error("\`app-name-here/components/foo.js\` does not contain a \`default export\`. Did you forget to export the component class?");
           `,
         },
       },


### PR DESCRIPTION
As mentioned in https://github.com/ember-cli/ember-cli-htmlbars/pull/772, the error message for re-exported classes with a different template is not very descriptive. This PR fixes that, let me know what you think of this new error message. Note that I adjusted the file path of the other error message as well, as it contained `.hbs`, while in fact the error was about the `.js` file.