### PR TITLE
Cleanup unused options

### DIFF
--- a/lib/ember-addon-main.js
+++ b/lib/ember-addon-main.js
@@ -58,12 +58,9 @@ module.exports = {
     return this._cachedShouldColocateTemplates;
   },
 
-  // This method is monkey patched by CSS Blocks,
-  // Please coordinate with @chriseppstein if you need to change it.
-  transpileTree(inputTree, htmlbarsOptions) {
+  transpileTree(inputTree) {
     const TemplateCompiler = require('./template-compiler-plugin');
-
-    return new TemplateCompiler(inputTree, htmlbarsOptions, this._requiresModuleApiPolyfill);
+    return new TemplateCompiler(inputTree);
   },
 
   setupPreprocessorRegistry(type, registry) {
@@ -85,7 +82,6 @@ module.exports = {
         );
 
         let shouldColocateTemplates = this._addon._shouldColocateTemplates();
-        let htmlbarsOptions = this._addon.htmlbarsOptions();
 
         let inputTree = debugTree(tree, '01-input');
 
@@ -95,14 +91,7 @@ module.exports = {
           inputTree = debugTree(new ColocatedTemplateProcessor(inputTree), '02-colocated-output');
         }
 
-        this._addon.logger.debug(`setup *.hbs compiler with ${htmlbarsOptions.pluginNames}`);
-        let output = debugTree(
-          this._addon.transpileTree(inputTree, {
-            isProduction,
-            ...htmlbarsOptions,
-          }),
-          '03-output'
-        );
+        let output = debugTree(this._addon.transpileTree(inputTree), '03-output');
 
         let checker = new VersionChecker(this._addon.project).for('ember-cli', 'npm');
         let requiresBabelTree = checker.lt('3.13.0');

--- a/lib/template-compiler-plugin.js
+++ b/lib/template-compiler-plugin.js
@@ -4,11 +4,8 @@ const Filter = require('broccoli-persistent-filter');
 const jsStringEscape = require('js-string-escape');
 
 class TemplateCompiler extends Filter {
-  constructor(inputTree, options = {}) {
-    if (!('persist' in options)) {
-      options.persist = true;
-    }
-    super(inputTree, options);
+  constructor(inputTree) {
+    super(inputTree, { persist: true });
   }
 
   baseDir() {


### PR DESCRIPTION
This is cleanup as an extension to #749. These options stopped really being used at that point.

In the unused options is a complete evaluated copy of the whole ember-template-compiler.js, which is how I noticed this. Loading all that is unnecessary work.